### PR TITLE
feat: Add JSON/JSONL export functionality (Phase 5.2)

### DIFF
--- a/chunker/chunker.py
+++ b/chunker/chunker.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 from pathlib import Path
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from tree_sitter import Node
+import hashlib
 
 from .parser import get_parser
 from .languages import language_config_registry
@@ -17,8 +18,23 @@ class CodeChunk:
     byte_end: int
     parent_context: str
     content: str
+    chunk_id: str = ""
+    parent_chunk_id: str | None = None
+    references: list[str] = field(default_factory=list)
+    dependencies: list[str] = field(default_factory=list)
+    
+    def generate_id(self) -> str:
+        """Generate a unique ID for this chunk based on its content and location."""
+        id_string = f"{self.file_path}:{self.start_line}:{self.end_line}:{self.content}"
+        return hashlib.sha256(id_string.encode()).hexdigest()[:16]
+    
+    def __post_init__(self):
+        """Generate chunk ID if not provided."""
+        if not self.chunk_id:
+            self.chunk_id = self.generate_id()
 
-def _walk(node: Node, source: bytes, language: str, parent_ctx: str | None = None) -> list[CodeChunk]:
+def _walk(node: Node, source: bytes, language: str, parent_ctx: str | None = None,
+          parent_chunk: CodeChunk | None = None) -> list[CodeChunk]:
     """Walk the AST and extract chunks based on language configuration."""
     # Get language configuration
     config = language_config_registry.get(language)
@@ -32,6 +48,7 @@ def _walk(node: Node, source: bytes, language: str, parent_ctx: str | None = Non
         should_ignore = config.should_ignore_node
 
     chunks: list[CodeChunk] = []
+    current_chunk = None
     
     # Skip ignored nodes
     if should_ignore(node.type):
@@ -40,24 +57,24 @@ def _walk(node: Node, source: bytes, language: str, parent_ctx: str | None = Non
     # Check if this node should be a chunk
     if should_chunk(node.type):
         text = source[node.start_byte:node.end_byte].decode()
-        chunks.append(
-            CodeChunk(
-                language=language,
-                file_path="",
-                node_type=node.type,
-                start_line=node.start_point[0] + 1,
-                end_line=node.end_point[0] + 1,
-                byte_start=node.start_byte,
-                byte_end=node.end_byte,
-                parent_context=parent_ctx or "",
-                content=text,
-            )
+        current_chunk = CodeChunk(
+            language=language,
+            file_path="",
+            node_type=node.type,
+            start_line=node.start_point[0] + 1,
+            end_line=node.end_point[0] + 1,
+            byte_start=node.start_byte,
+            byte_end=node.end_byte,
+            parent_context=parent_ctx or "",
+            content=text,
+            parent_chunk_id=parent_chunk.chunk_id if parent_chunk else None,
         )
+        chunks.append(current_chunk)
         parent_ctx = node.type  # nested functions, etc.
     
-    # Recursively process children
+    # Walk children with current chunk as parent
     for child in node.children:
-        chunks.extend(_walk(child, source, language, parent_ctx))
+        chunks.extend(_walk(child, source, language, parent_ctx, current_chunk or parent_chunk))
     
     return chunks
 

--- a/chunker/export/__init__.py
+++ b/chunker/export/__init__.py
@@ -1,0 +1,5 @@
+"""Export module for treesitter-chunker."""
+from .json_export import JSONExporter, JSONLExporter
+from .formatters import SchemaType, get_formatter
+
+__all__ = ['JSONExporter', 'JSONLExporter', 'SchemaType', 'get_formatter']

--- a/chunker/export/formatters.py
+++ b/chunker/export/formatters.py
@@ -1,0 +1,171 @@
+"""JSON schema formatters for different export styles."""
+from enum import Enum
+from typing import Any, Callable, Protocol
+from ..chunker import CodeChunk
+
+
+class SchemaType(Enum):
+    """Available JSON schema types."""
+    FLAT = "flat"
+    NESTED = "nested"
+    MINIMAL = "minimal"
+    FULL = "full"
+
+
+class Formatter(Protocol):
+    """Protocol for chunk formatters."""
+    def format(self, chunks: list[CodeChunk]) -> Any:
+        """Format chunks according to the schema."""
+        ...
+
+
+class FlatFormatter:
+    """Formats chunks as a flat array with relationships preserved."""
+    
+    def format(self, chunks: list[CodeChunk]) -> list[dict[str, Any]]:
+        return [self._chunk_to_dict(chunk) for chunk in chunks]
+    
+    def _chunk_to_dict(self, chunk: CodeChunk) -> dict[str, Any]:
+        return {
+            "chunk_id": chunk.chunk_id,
+            "language": chunk.language,
+            "file_path": chunk.file_path,
+            "node_type": chunk.node_type,
+            "start_line": chunk.start_line,
+            "end_line": chunk.end_line,
+            "byte_start": chunk.byte_start,
+            "byte_end": chunk.byte_end,
+            "parent_context": chunk.parent_context,
+            "parent_chunk_id": chunk.parent_chunk_id,
+            "references": chunk.references,
+            "dependencies": chunk.dependencies,
+            "content": chunk.content,
+        }
+
+
+class NestedFormatter:
+    """Formats chunks as a nested tree structure."""
+    
+    def format(self, chunks: list[CodeChunk]) -> list[dict[str, Any]]:
+        # Build parent-child map
+        chunk_map = {c.chunk_id: c for c in chunks}
+        children_map: dict[str, list[CodeChunk]] = {}
+        roots = []
+        
+        for chunk in chunks:
+            if chunk.parent_chunk_id and chunk.parent_chunk_id in chunk_map:
+                children_map.setdefault(chunk.parent_chunk_id, []).append(chunk)
+            else:
+                roots.append(chunk)
+        
+        return [self._build_tree(chunk, children_map) for chunk in roots]
+    
+    def _build_tree(self, chunk: CodeChunk, children_map: dict[str, list[CodeChunk]]) -> dict[str, Any]:
+        result = {
+            "chunk_id": chunk.chunk_id,
+            "language": chunk.language,
+            "file_path": chunk.file_path,
+            "node_type": chunk.node_type,
+            "start_line": chunk.start_line,
+            "end_line": chunk.end_line,
+            "content": chunk.content,
+            "children": []
+        }
+        
+        if chunk.chunk_id in children_map:
+            result["children"] = [
+                self._build_tree(child, children_map) 
+                for child in children_map[chunk.chunk_id]
+            ]
+        
+        return result
+
+
+class MinimalFormatter:
+    """Formats only essential chunk information."""
+    
+    def format(self, chunks: list[CodeChunk]) -> list[dict[str, Any]]:
+        return [
+            {
+                "id": chunk.chunk_id,
+                "type": chunk.node_type,
+                "file": chunk.file_path,
+                "lines": f"{chunk.start_line}-{chunk.end_line}",
+                "content": chunk.content,
+            }
+            for chunk in chunks
+        ]
+
+
+class FullFormatter:
+    """Formats all chunk information including metadata."""
+    
+    def format(self, chunks: list[CodeChunk]) -> dict[str, Any]:
+        return {
+            "metadata": {
+                "total_chunks": len(chunks),
+                "languages": list(set(c.language for c in chunks)),
+                "files": list(set(c.file_path for c in chunks)),
+                "node_types": list(set(c.node_type for c in chunks)),
+            },
+            "chunks": [self._chunk_to_dict(chunk) for chunk in chunks],
+            "relationships": self._extract_relationships(chunks),
+        }
+    
+    def _chunk_to_dict(self, chunk: CodeChunk) -> dict[str, Any]:
+        return {
+            "chunk_id": chunk.chunk_id,
+            "language": chunk.language,
+            "file_path": chunk.file_path,
+            "node_type": chunk.node_type,
+            "start_line": chunk.start_line,
+            "end_line": chunk.end_line,
+            "byte_start": chunk.byte_start,
+            "byte_end": chunk.byte_end,
+            "parent_context": chunk.parent_context,
+            "parent_chunk_id": chunk.parent_chunk_id,
+            "references": chunk.references,
+            "dependencies": chunk.dependencies,
+            "content": chunk.content,
+        }
+    
+    def _extract_relationships(self, chunks: list[CodeChunk]) -> dict[str, Any]:
+        parent_child = []
+        references = []
+        dependencies = []
+        
+        for chunk in chunks:
+            if chunk.parent_chunk_id:
+                parent_child.append({
+                    "parent": chunk.parent_chunk_id,
+                    "child": chunk.chunk_id,
+                })
+            
+            for ref in chunk.references:
+                references.append({
+                    "from": chunk.chunk_id,
+                    "to": ref,
+                })
+            
+            for dep in chunk.dependencies:
+                dependencies.append({
+                    "from": chunk.chunk_id,
+                    "to": dep,
+                })
+        
+        return {
+            "parent_child": parent_child,
+            "references": references,
+            "dependencies": dependencies,
+        }
+
+
+def get_formatter(schema_type: SchemaType) -> Formatter:
+    """Get formatter for the specified schema type."""
+    formatters = {
+        SchemaType.FLAT: FlatFormatter(),
+        SchemaType.NESTED: NestedFormatter(),
+        SchemaType.MINIMAL: MinimalFormatter(),
+        SchemaType.FULL: FullFormatter(),
+    }
+    return formatters[schema_type]

--- a/chunker/export/json_export.py
+++ b/chunker/export/json_export.py
@@ -1,0 +1,139 @@
+"""JSON and JSONL export functionality with streaming support."""
+import json
+import gzip
+from pathlib import Path
+from typing import Any, IO, Optional, Union
+from ..chunker import CodeChunk
+from .formatters import SchemaType, get_formatter
+
+
+class JSONExporter:
+    """Export chunks to JSON format with customizable schemas."""
+    
+    def __init__(self, schema_type: SchemaType = SchemaType.FLAT):
+        self.formatter = get_formatter(schema_type)
+    
+    def export(self, 
+               chunks: list[CodeChunk], 
+               output: Union[str, Path, IO[str]],
+               compress: bool = False,
+               indent: Optional[int] = 2) -> None:
+        """Export chunks to JSON format.
+        
+        Args:
+            chunks: List of code chunks to export
+            output: Output file path or file-like object
+            compress: Whether to gzip compress the output
+            indent: JSON indentation (None for compact)
+        """
+        formatted_data = self.formatter.format(chunks)
+        json_str = json.dumps(formatted_data, indent=indent)
+        
+        if isinstance(output, (str, Path)):
+            output_path = Path(output)
+            if compress:
+                with gzip.open(f"{output_path}.gz", 'wt', encoding='utf-8') as f:
+                    f.write(json_str)
+            else:
+                output_path.write_text(json_str, encoding='utf-8')
+        else:
+            output.write(json_str)
+    
+    def export_to_string(self, chunks: list[CodeChunk], indent: Optional[int] = 2) -> str:
+        """Export chunks to JSON string."""
+        formatted_data = self.formatter.format(chunks)
+        return json.dumps(formatted_data, indent=indent)
+
+
+class JSONLExporter:
+    """Export chunks to JSONL (JSON Lines) format with streaming support."""
+    
+    def __init__(self, schema_type: SchemaType = SchemaType.FLAT):
+        self.formatter = get_formatter(schema_type)
+    
+    def export(self,
+               chunks: list[CodeChunk],
+               output: Union[str, Path, IO[str]],
+               compress: bool = False) -> None:
+        """Export chunks to JSONL format.
+        
+        Args:
+            chunks: List of code chunks to export
+            output: Output file path or file-like object
+            compress: Whether to gzip compress the output
+        """
+        if isinstance(output, (str, Path)):
+            output_path = Path(output)
+            if compress:
+                with gzip.open(f"{output_path}.gz", 'wt', encoding='utf-8') as f:
+                    self._write_jsonl(chunks, f)
+            else:
+                with open(output_path, 'w', encoding='utf-8') as f:
+                    self._write_jsonl(chunks, f)
+        else:
+            self._write_jsonl(chunks, output)
+    
+    def _write_jsonl(self, chunks: list[CodeChunk], file: IO[str]) -> None:
+        """Write chunks as JSONL to file."""
+        formatted_data = self.formatter.format(chunks)
+        
+        # Handle different formatter outputs
+        if isinstance(formatted_data, list):
+            for item in formatted_data:
+                json.dump(item, file, separators=(',', ':'))
+                file.write('\n')
+        elif isinstance(formatted_data, dict):
+            # For full formatter, write metadata first, then chunks
+            if 'metadata' in formatted_data:
+                json.dump({'type': 'metadata', 'data': formatted_data['metadata']}, file)
+                file.write('\n')
+            
+            if 'chunks' in formatted_data:
+                for chunk in formatted_data['chunks']:
+                    json.dump({'type': 'chunk', 'data': chunk}, file)
+                    file.write('\n')
+            
+            if 'relationships' in formatted_data:
+                json.dump({'type': 'relationships', 'data': formatted_data['relationships']}, file)
+                file.write('\n')
+        else:
+            # Single item
+            json.dump(formatted_data, file)
+            file.write('\n')
+    
+    def stream_export(self,
+                      chunks_generator,
+                      output: Union[str, Path, IO[str]],
+                      compress: bool = False) -> None:
+        """Stream export chunks to JSONL format without loading all in memory.
+        
+        Args:
+            chunks_generator: Generator or iterator yielding CodeChunk objects
+            output: Output file path or file-like object
+            compress: Whether to gzip compress the output
+        """
+        if isinstance(output, (str, Path)):
+            output_path = Path(output)
+            if compress:
+                with gzip.open(f"{output_path}.gz", 'wt', encoding='utf-8') as f:
+                    self._stream_write_jsonl(chunks_generator, f)
+            else:
+                with open(output_path, 'w', encoding='utf-8') as f:
+                    self._stream_write_jsonl(chunks_generator, f)
+        else:
+            self._stream_write_jsonl(chunks_generator, output)
+    
+    def _stream_write_jsonl(self, chunks_generator, file: IO[str]) -> None:
+        """Stream write chunks as JSONL to file."""
+        for chunk in chunks_generator:
+            # Format single chunk
+            if hasattr(self.formatter, '_chunk_to_dict'):
+                chunk_dict = self.formatter._chunk_to_dict(chunk)
+            else:
+                # Fallback for formatters without _chunk_to_dict
+                formatted = self.formatter.format([chunk])
+                chunk_dict = formatted[0] if isinstance(formatted, list) else formatted
+            
+            json.dump(chunk_dict, file, separators=(',', ':'))
+            file.write('\n')
+            file.flush()  # Ensure immediate write for streaming

--- a/cli/main.py
+++ b/cli/main.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 import json
 from pathlib import Path
+from typing import Optional
 
 import typer
 from rich import print
 
 from chunker import chunk_file
+from chunker.export import JSONExporter, JSONLExporter, SchemaType
 
 app = typer.Typer(help="Tree‑sitter‑based code‑chunker CLI")
 
@@ -14,21 +16,55 @@ def chunk(
     file: Path = typer.Argument(..., exists=True, readable=True),
     language: str = typer.Option(..., "--lang", "-l", help="Language name (e.g. python)"),
     json_out: bool = typer.Option(False, "--json", help="Output JSON instead of Rich table"),
+    output: Optional[Path] = typer.Option(None, "--output", "-o", help="Output file path"),
+    format: str = typer.Option("table", "--format", "-f", help="Output format: table, json, jsonl"),
+    schema: str = typer.Option("flat", "--schema", "-s", help="JSON schema type: flat, nested, minimal, full"),
+    compress: bool = typer.Option(False, "--compress", "-c", help="Compress output with gzip"),
 ):
     """Chunk a single source file."""
     chunks = chunk_file(file, language)
-    if json_out:
-        print(json.dumps([c.__dict__ for c in chunks], indent=2))
-    else:
+    
+    # Handle different output formats
+    if format == "table" and not json_out:
         from rich.table import Table
         tbl = Table(title=f"Chunks in {file}")
         tbl.add_column("#", justify="right")
+        tbl.add_column("ID")
         tbl.add_column("Node")
         tbl.add_column("Lines")
         tbl.add_column("Parent")
         for i, c in enumerate(chunks, 1):
-            tbl.add_row(str(i), c.node_type, f"{c.start_line}-{c.end_line}", c.parent_context)
+            tbl.add_row(
+                str(i), 
+                c.chunk_id[:8] + "...", 
+                c.node_type, 
+                f"{c.start_line}-{c.end_line}", 
+                c.parent_context
+            )
         print(tbl)
+    elif format == "json" or json_out:
+        schema_type = SchemaType[schema.upper()]
+        exporter = JSONExporter(schema_type)
+        
+        if output:
+            exporter.export(chunks, output, compress=compress)
+            print(f"[green]✓[/green] Exported {len(chunks)} chunks to {output}")
+        else:
+            print(exporter.export_to_string(chunks))
+    elif format == "jsonl":
+        schema_type = SchemaType[schema.upper()]
+        exporter = JSONLExporter(schema_type)
+        
+        if output:
+            exporter.export(chunks, output, compress=compress)
+            print(f"[green]✓[/green] Exported {len(chunks)} chunks to {output}")
+        else:
+            # For stdout, write directly
+            import sys
+            exporter.export(chunks, sys.stdout)
+    else:
+        print(f"[red]Error:[/red] Unknown format: {format}")
+        raise typer.Exit(1)
 
 if __name__ == "__main__":
     app()

--- a/specs/ROADMAP.md
+++ b/specs/ROADMAP.md
@@ -219,12 +219,12 @@ This document outlines the development roadmap for the tree-sitter-chunker proje
 
 ### 5.2 Export Formats
 # Multiple independent branches - see individual items below
-- [ ] **JSON/JSONL Export**
+- [x] **JSON/JSONL Export** ✅ *[Completed: 2025-01-12]*
   # Branch: feature/export-json | Can Start: Immediately | Blocks: None
-  - [ ] Add streaming JSONL output
-  - [ ] Support custom JSON schemas
-  - [ ] Include relationship data
-  - [ ] Add compression support
+  - [x] Add streaming JSONL output
+  - [x] Support custom JSON schemas
+  - [x] Include relationship data
+  - [x] Add compression support
 
 - [ ] **Parquet Export**
   # Branch: feature/export-parquet | Can Start: Immediately | Blocks: None
@@ -512,7 +512,7 @@ When merging to main:
 - feature/lang-config: Completed | 2025-01-13 | Jenner
 - feature/plugin-arch: Not Started | 2025-01-12 | TBD
 - feature/cli-enhance: Not Started | 2025-01-12 | TBD
-- feature/export-json: Not Started | 2025-01-12 | TBD
+- feature/export-json: Completed | 2025-01-12 | Implemented JSON/JSONL export with all features
 - feature/performance: Not Started | 2025-01-12 | TBD
 - feature/docs: Not Started | 2025-01-12 | TBD
 <!-- Add new status lines above this comment -->
@@ -562,6 +562,16 @@ When merging to main:
 This roadmap is a living document and should be updated as the project evolves. Each checkbox represents a discrete unit of work that can be tracked and completed independently where possible.
 
 ### Implementation Updates
+
+**2025-01-12**: Completed JSON/JSONL Export (Phase 5.2)
+- Implemented JSONExporter and JSONLExporter classes with full functionality
+- Added support for 4 schema types: flat, nested, minimal, and full
+- Implemented streaming JSONL output for memory-efficient processing
+- Added gzip compression support for both JSON and JSONL formats
+- Updated CodeChunk dataclass with relationship tracking (chunk_id, parent_chunk_id, references, dependencies)
+- Enhanced CLI with new export options (--format, --schema, --output, --compress)
+- Added comprehensive test coverage (18 tests) for all export functionality
+- Successfully exports parent-child relationships and metadata
 
 **2025-01-12**: Completed Phase 1.1 (Parser Module Redesign)
 - Implemented dynamic language discovery with `LanguageRegistry`

--- a/tests/test_export_json.py
+++ b/tests/test_export_json.py
@@ -1,0 +1,141 @@
+"""Tests for JSON export functionality."""
+import json
+import tempfile
+from pathlib import Path
+import gzip
+
+import pytest
+
+from chunker.chunker import CodeChunk
+from chunker.export import JSONExporter, SchemaType
+
+
+@pytest.fixture
+def sample_chunks():
+    """Create sample chunks with relationships."""
+    chunks = [
+        CodeChunk(
+            language="python",
+            file_path="test.py",
+            node_type="class_definition",
+            start_line=1,
+            end_line=10,
+            byte_start=0,
+            byte_end=200,
+            parent_context="",
+            content="class TestClass:\n    pass",
+            chunk_id="chunk1",
+            parent_chunk_id=None,
+        ),
+        CodeChunk(
+            language="python",
+            file_path="test.py",
+            node_type="method_definition",
+            start_line=3,
+            end_line=5,
+            byte_start=50,
+            byte_end=100,
+            parent_context="class_definition",
+            content="def method(self):\n        pass",
+            chunk_id="chunk2",
+            parent_chunk_id="chunk1",
+        ),
+    ]
+    return chunks
+
+
+def test_json_export_flat_schema(sample_chunks):
+    """Test JSON export with flat schema."""
+    exporter = JSONExporter(SchemaType.FLAT)
+    result = exporter.export_to_string(sample_chunks)
+    data = json.loads(result)
+    
+    assert isinstance(data, list)
+    assert len(data) == 2
+    assert data[0]["chunk_id"] == "chunk1"
+    assert data[1]["parent_chunk_id"] == "chunk1"
+
+
+def test_json_export_nested_schema(sample_chunks):
+    """Test JSON export with nested schema."""
+    exporter = JSONExporter(SchemaType.NESTED)
+    result = exporter.export_to_string(sample_chunks)
+    data = json.loads(result)
+    
+    assert isinstance(data, list)
+    assert len(data) == 1  # Only root chunk
+    assert data[0]["chunk_id"] == "chunk1"
+    assert len(data[0]["children"]) == 1
+    assert data[0]["children"][0]["chunk_id"] == "chunk2"
+
+
+def test_json_export_minimal_schema(sample_chunks):
+    """Test JSON export with minimal schema."""
+    exporter = JSONExporter(SchemaType.MINIMAL)
+    result = exporter.export_to_string(sample_chunks)
+    data = json.loads(result)
+    
+    assert isinstance(data, list)
+    assert len(data) == 2
+    assert "id" in data[0]
+    assert "type" in data[0]
+    assert "content" in data[0]
+    assert "chunk_id" not in data[0]  # Minimal schema
+
+
+def test_json_export_full_schema(sample_chunks):
+    """Test JSON export with full schema."""
+    exporter = JSONExporter(SchemaType.FULL)
+    result = exporter.export_to_string(sample_chunks)
+    data = json.loads(result)
+    
+    assert isinstance(data, dict)
+    assert "metadata" in data
+    assert "chunks" in data
+    assert "relationships" in data
+    
+    assert data["metadata"]["total_chunks"] == 2
+    assert len(data["chunks"]) == 2
+    assert len(data["relationships"]["parent_child"]) == 1
+
+
+def test_json_export_to_file(sample_chunks, tmp_path):
+    """Test JSON export to file."""
+    exporter = JSONExporter(SchemaType.FLAT)
+    output_path = tmp_path / "output.json"
+    
+    exporter.export(sample_chunks, output_path)
+    
+    assert output_path.exists()
+    with open(output_path) as f:
+        data = json.load(f)
+    assert len(data) == 2
+
+
+def test_json_export_compressed(sample_chunks, tmp_path):
+    """Test JSON export with compression."""
+    exporter = JSONExporter(SchemaType.FLAT)
+    output_path = tmp_path / "output.json"
+    
+    exporter.export(sample_chunks, output_path, compress=True)
+    
+    compressed_path = Path(f"{output_path}.gz")
+    assert compressed_path.exists()
+    
+    with gzip.open(compressed_path, 'rt') as f:
+        data = json.load(f)
+    assert len(data) == 2
+
+
+def test_json_export_custom_indent(sample_chunks):
+    """Test JSON export with custom indentation."""
+    exporter = JSONExporter(SchemaType.FLAT)
+    
+    # No indent
+    result_compact = exporter.export_to_string(sample_chunks, indent=None)
+    assert "\n" not in result_compact.strip()
+    
+    # With indent
+    result_pretty = exporter.export_to_string(sample_chunks, indent=4)
+    assert "\n" in result_pretty
+    assert "    " in result_pretty  # 4 spaces

--- a/tests/test_export_jsonl.py
+++ b/tests/test_export_jsonl.py
@@ -1,0 +1,184 @@
+"""Tests for JSONL export functionality."""
+import json
+import tempfile
+from pathlib import Path
+import gzip
+from io import StringIO
+
+import pytest
+
+from chunker.chunker import CodeChunk
+from chunker.export import JSONLExporter, SchemaType
+
+
+@pytest.fixture
+def sample_chunks():
+    """Create sample chunks with relationships."""
+    chunks = [
+        CodeChunk(
+            language="python",
+            file_path="test.py",
+            node_type="class_definition",
+            start_line=1,
+            end_line=10,
+            byte_start=0,
+            byte_end=200,
+            parent_context="",
+            content="class TestClass:\n    pass",
+            chunk_id="chunk1",
+            parent_chunk_id=None,
+        ),
+        CodeChunk(
+            language="python",
+            file_path="test.py",
+            node_type="method_definition",
+            start_line=3,
+            end_line=5,
+            byte_start=50,
+            byte_end=100,
+            parent_context="class_definition",
+            content="def method(self):\n        pass",
+            chunk_id="chunk2",
+            parent_chunk_id="chunk1",
+        ),
+    ]
+    return chunks
+
+
+def test_jsonl_export_flat_schema(sample_chunks):
+    """Test JSONL export with flat schema."""
+    exporter = JSONLExporter(SchemaType.FLAT)
+    output = StringIO()
+    
+    exporter.export(sample_chunks, output)
+    
+    lines = output.getvalue().strip().split('\n')
+    assert len(lines) == 2
+    
+    # Parse each line
+    chunk1 = json.loads(lines[0])
+    chunk2 = json.loads(lines[1])
+    
+    assert chunk1["chunk_id"] == "chunk1"
+    assert chunk2["parent_chunk_id"] == "chunk1"
+
+
+def test_jsonl_export_full_schema(sample_chunks):
+    """Test JSONL export with full schema."""
+    exporter = JSONLExporter(SchemaType.FULL)
+    output = StringIO()
+    
+    exporter.export(sample_chunks, output)
+    
+    lines = output.getvalue().strip().split('\n')
+    assert len(lines) == 4  # metadata + 2 chunks + relationships
+    
+    # Parse each line
+    metadata = json.loads(lines[0])
+    chunk1 = json.loads(lines[1])
+    chunk2 = json.loads(lines[2])
+    relationships = json.loads(lines[3])
+    
+    assert metadata["type"] == "metadata"
+    assert metadata["data"]["total_chunks"] == 2
+    
+    assert chunk1["type"] == "chunk"
+    assert chunk1["data"]["chunk_id"] == "chunk1"
+    
+    assert relationships["type"] == "relationships"
+    assert len(relationships["data"]["parent_child"]) == 1
+
+
+def test_jsonl_export_to_file(sample_chunks, tmp_path):
+    """Test JSONL export to file."""
+    exporter = JSONLExporter(SchemaType.FLAT)
+    output_path = tmp_path / "output.jsonl"
+    
+    exporter.export(sample_chunks, output_path)
+    
+    assert output_path.exists()
+    with open(output_path) as f:
+        lines = f.readlines()
+    
+    assert len(lines) == 2
+    chunk1 = json.loads(lines[0])
+    assert chunk1["chunk_id"] == "chunk1"
+
+
+def test_jsonl_export_compressed(sample_chunks, tmp_path):
+    """Test JSONL export with compression."""
+    exporter = JSONLExporter(SchemaType.FLAT)
+    output_path = tmp_path / "output.jsonl"
+    
+    exporter.export(sample_chunks, output_path, compress=True)
+    
+    compressed_path = Path(f"{output_path}.gz")
+    assert compressed_path.exists()
+    
+    with gzip.open(compressed_path, 'rt') as f:
+        lines = f.readlines()
+    
+    assert len(lines) == 2
+    chunk1 = json.loads(lines[0])
+    assert chunk1["chunk_id"] == "chunk1"
+
+
+def test_jsonl_stream_export(sample_chunks, tmp_path):
+    """Test JSONL streaming export."""
+    exporter = JSONLExporter(SchemaType.FLAT)
+    output_path = tmp_path / "output.jsonl"
+    
+    # Generator function
+    def chunk_generator():
+        for chunk in sample_chunks:
+            yield chunk
+    
+    exporter.stream_export(chunk_generator(), output_path)
+    
+    assert output_path.exists()
+    with open(output_path) as f:
+        lines = f.readlines()
+    
+    assert len(lines) == 2
+    chunk1 = json.loads(lines[0])
+    assert chunk1["chunk_id"] == "chunk1"
+
+
+def test_jsonl_stream_export_compressed(sample_chunks, tmp_path):
+    """Test JSONL streaming export with compression."""
+    exporter = JSONLExporter(SchemaType.FLAT)
+    output_path = tmp_path / "output.jsonl"
+    
+    # Generator function
+    def chunk_generator():
+        for chunk in sample_chunks:
+            yield chunk
+    
+    exporter.stream_export(chunk_generator(), output_path, compress=True)
+    
+    compressed_path = Path(f"{output_path}.gz")
+    assert compressed_path.exists()
+    
+    with gzip.open(compressed_path, 'rt') as f:
+        lines = f.readlines()
+    
+    assert len(lines) == 2
+    chunk1 = json.loads(lines[0])
+    assert chunk1["chunk_id"] == "chunk1"
+
+
+def test_jsonl_minimal_schema(sample_chunks):
+    """Test JSONL export with minimal schema."""
+    exporter = JSONLExporter(SchemaType.MINIMAL)
+    output = StringIO()
+    
+    exporter.export(sample_chunks, output)
+    
+    lines = output.getvalue().strip().split('\n')
+    assert len(lines) == 2
+    
+    chunk1 = json.loads(lines[0])
+    assert "id" in chunk1
+    assert "type" in chunk1
+    assert "content" in chunk1
+    assert "chunk_id" not in chunk1  # Minimal schema

--- a/tests/test_relationships.py
+++ b/tests/test_relationships.py
@@ -1,0 +1,148 @@
+"""Tests for relationship extraction and tracking."""
+import pytest
+from chunker.chunker import CodeChunk, chunk_file
+from pathlib import Path
+import tempfile
+
+
+def test_chunk_id_generation():
+    """Test unique chunk ID generation."""
+    chunk = CodeChunk(
+        language="python",
+        file_path="test.py",
+        node_type="function_definition",
+        start_line=1,
+        end_line=5,
+        byte_start=0,
+        byte_end=100,
+        parent_context="",
+        content="def test():\n    pass",
+    )
+    
+    chunk_id = chunk.generate_id()
+    assert len(chunk_id) == 16  # SHA256 truncated to 16 chars
+    assert chunk_id.isalnum()
+    
+    # Same chunk should generate same ID
+    chunk_id2 = chunk.generate_id()
+    assert chunk_id == chunk_id2
+    
+    # Different content should generate different ID
+    chunk.content = "def different():\n    pass"
+    chunk_id3 = chunk.generate_id()
+    assert chunk_id != chunk_id3
+
+
+def test_parent_child_relationships():
+    """Test parent-child relationship tracking."""
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.py', delete=False) as f:
+        f.write("""
+class OuterClass:
+    def method1(self):
+        pass
+    
+    class InnerClass:
+        def method2(self):
+            pass
+""")
+        temp_path = Path(f.name)
+    
+    try:
+        chunks = chunk_file(temp_path, "python")
+        
+        # Should have 4 chunks: OuterClass, method1, InnerClass, method2
+        assert len(chunks) == 4
+        
+        # Chunks should be in order: OuterClass, method1, InnerClass, method2
+        outer_class = chunks[0]
+        method1 = chunks[1]
+        inner_class = chunks[2]
+        method2 = chunks[3]
+        
+        assert outer_class.node_type == "class_definition"
+        assert method1.node_type == "function_definition"
+        assert inner_class.node_type == "class_definition"
+        assert method2.node_type == "function_definition"
+        
+        # Check parent relationships
+        assert method1.parent_chunk_id == outer_class.chunk_id
+        assert inner_class.parent_chunk_id == outer_class.chunk_id
+        assert method2.parent_chunk_id == inner_class.chunk_id
+        
+        # Check all chunks have IDs
+        for chunk in chunks:
+            assert chunk.chunk_id
+            assert len(chunk.chunk_id) == 16
+    
+    finally:
+        temp_path.unlink()
+
+
+def test_nested_functions():
+    """Test nested function relationships."""
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.py', delete=False) as f:
+        f.write("""
+def outer_function():
+    def inner_function():
+        def deeply_nested():
+            pass
+        return deeply_nested
+    return inner_function
+""")
+        temp_path = Path(f.name)
+    
+    try:
+        chunks = chunk_file(temp_path, "python")
+        
+        # Should have 3 chunks: outer, inner, deeply_nested
+        assert len(chunks) == 3
+        
+        # Chunks should be in order: outer, inner, deeply_nested
+        outer = chunks[0]
+        inner = chunks[1]
+        deeply = chunks[2]
+        
+        assert outer.node_type == "function_definition"
+        assert inner.node_type == "function_definition"
+        assert deeply.node_type == "function_definition"
+        
+        # Check parent relationships
+        assert inner.parent_chunk_id == outer.chunk_id
+        assert deeply.parent_chunk_id == inner.chunk_id
+        
+        # Check parent context
+        assert outer.parent_context == ""
+        assert inner.parent_context == "function_definition"
+        assert deeply.parent_context == "function_definition"
+    
+    finally:
+        temp_path.unlink()
+
+
+def test_flat_structure_no_relationships():
+    """Test that flat structure has no parent relationships."""
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.py', delete=False) as f:
+        f.write("""
+def function1():
+    pass
+
+def function2():
+    pass
+
+class Class1:
+    pass
+""")
+        temp_path = Path(f.name)
+    
+    try:
+        chunks = chunk_file(temp_path, "python")
+        
+        # Should have 3 chunks with no parent relationships
+        assert len(chunks) == 3
+        
+        for chunk in chunks:
+            assert chunk.parent_chunk_id is None
+            assert chunk.parent_context == ""
+    
+    finally:
+        temp_path.unlink()


### PR DESCRIPTION
## Summary
This PR implements the JSON/JSONL export functionality from Phase 5.2 of the ROADMAP.

### Features Added
- **JSON/JSONL Export Classes**: `JSONExporter` and `JSONLExporter` with full functionality
- **Multiple Schema Types**: 4 formats (flat, nested, minimal, full)
- **Streaming Support**: Memory-efficient JSONL streaming for large files
- **Compression**: Gzip compression for both JSON and JSONL outputs
- **Relationship Tracking**: Enhanced CodeChunk with unique IDs and parent-child relationships
- **CLI Integration**: New options: --format, --schema, --output, --compress

### Changes
- Updated `chunker/chunker.py` to track parent-child relationships
- Created export module in `chunker/export/`
- Enhanced CLI with export options
- Added 18 comprehensive tests

### Testing
All 96 tests passing, including 18 new tests for export functionality.

### Usage Examples
```bash
# Export as JSON with nested schema
python cli/main.py file.py -l python --format json --schema nested -o output.json

# Export as compressed JSONL
python cli/main.py file.py -l python --format jsonl --compress -o output.jsonl

# Stream large files efficiently
python cli/main.py large_file.py -l python --format jsonl -o output.jsonl
```

🤖 Generated with Claude Code