### PR TITLE
feat(export): add SemanticGraphBundle export format for semantic-lens

### DIFF
--- a/chunker/export/__init__.py
+++ b/chunker/export/__init__.py
@@ -5,6 +5,7 @@ from .formats import (
     GraphMLExporter,
     Neo4jExporter,
     PostgreSQLExporter,
+    SemanticLensExporter,
     SQLiteExporter,
     StructuredJSONExporter,
     StructuredJSONLExporter,
@@ -28,6 +29,7 @@ __all__ = [
     "JSONLExporter",
     "Neo4jExporter",
     "PostgreSQLExporter",
+    "SemanticLensExporter",
     "SQLiteExporter",
     "SchemaType",
     # Structured exports

--- a/chunker/export/formats/__init__.py
+++ b/chunker/export/formats/__init__.py
@@ -4,6 +4,7 @@ from .database import PostgreSQLExporter, SQLiteExporter
 from .graph import DOTExporter, GraphMLExporter
 from .json import StructuredJSONExporter, StructuredJSONLExporter
 from .neo4j import Neo4jExporter
+from .semantic_lens import SemanticLensExporter
 
 # Make Parquet optional at import time to avoid heavy dependency import errors
 try:  # pragma: no cover
@@ -19,6 +20,7 @@ __all__ = [
     "GraphMLExporter",
     "Neo4jExporter",
     "PostgreSQLExporter",
+    "SemanticLensExporter",
     "SQLiteExporter",
     "StructuredJSONExporter",
     "StructuredJSONLExporter",

--- a/chunker/export/formats/semantic_lens.py
+++ b/chunker/export/formats/semantic_lens.py
@@ -1,0 +1,475 @@
+"""Export chunks and relationships to SemanticGraphBundle format.
+
+SemanticGraphBundle is the input format for semantic-lens, a code
+visualization platform. See: https://github.com/[org]/semantic-lens
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from chunker.interfaces.export import (
+    ChunkRelationship,
+    ExportFormat,
+    ExportMetadata,
+    RelationshipType,
+    StructuredExporter,
+)
+
+if TYPE_CHECKING:
+    import io
+    from collections.abc import Iterator
+
+    from chunker.types import CodeChunk
+
+
+# Maps treesitter-chunker node_type to semantic-lens NodeKind
+NODE_KIND_MAP: dict[str, str] = {
+    # Direct mappings
+    "module": "module",
+    "class_definition": "class",
+    "class_declaration": "class",
+    "interface_declaration": "interface",
+    "interface_definition": "interface",
+    "trait_definition": "trait",
+    "trait_declaration": "trait",
+    "function_definition": "function",
+    "function_declaration": "function",
+    "arrow_function": "function",
+    "method_definition": "method",
+    "method_declaration": "method",
+    "field_definition": "field",
+    "field_declaration": "field",
+    "property_definition": "property",
+    "property_declaration": "property",
+    "property_signature": "property",
+    # Fallback mappings for common node types
+    "lexical_declaration": "property",  # const/let/var
+    "variable_declaration": "property",
+    "type_alias_declaration": "interface",
+    "enum_declaration": "class",
+}
+
+# Maps treesitter-chunker RelationshipType to semantic-lens EdgeKind
+EDGE_KIND_MAP: dict[RelationshipType, str] = {
+    RelationshipType.CALLS: "calls",
+    RelationshipType.IMPORTS: "imports",
+    RelationshipType.INHERITS: "inherits",
+    RelationshipType.IMPLEMENTS: "implements",
+    RelationshipType.DEFINES: "defines",
+    RelationshipType.USES: "uses",
+    RelationshipType.REFERENCES: "uses",
+    RelationshipType.HAS_METHOD: "defines",
+    RelationshipType.PARENT_CHILD: "defines",
+    RelationshipType.DEPENDS_ON: "uses",
+}
+
+# Valid semantic-lens node kinds (for validation)
+VALID_NODE_KINDS = frozenset([
+    "module", "class", "interface", "trait",
+    "function", "method", "field", "property",
+])
+
+# Valid semantic-lens edge kinds (for validation)
+VALID_EDGE_KINDS = frozenset([
+    "defines", "imports", "calls", "inherits",
+    "implements", "uses", "reads", "writes", "throws",
+])
+
+
+class SemanticLensExporter(StructuredExporter):
+    """Export to SemanticGraphBundle format for semantic-lens visualization.
+
+    SemanticGraphBundle is a JSON format containing:
+    - version: Schema version (v1.0)
+    - generated_at: ISO 8601 timestamp
+    - repo: Optional repository metadata
+    - nodes: Code elements (classes, functions, methods, etc.)
+    - edges: Relationships (calls, imports, inherits, etc.)
+    - annotations: Tags and metadata on nodes
+    - patterns: Detected design patterns (empty by default)
+
+    Attributes:
+        indent: JSON indentation level (None for compact)
+        include_content: Whether to include source code in annotations
+        repo_url: Optional repository URL for metadata
+        repo_commit: Optional commit hash for metadata
+        repo_branch: Optional branch name for metadata
+    """
+
+    VERSION = "v1.0"
+
+    def __init__(
+        self,
+        indent: int | None = 2,
+        include_content: bool = False,
+        repo_url: str | None = None,
+        repo_commit: str | None = None,
+        repo_branch: str | None = None,
+    ):
+        """Initialize SemanticLens exporter.
+
+        Args:
+            indent: JSON indentation (None for compact output)
+            include_content: Include source code as node annotations
+            repo_url: Repository URL for bundle metadata
+            repo_commit: Git commit hash (7+ chars)
+            repo_branch: Git branch name
+        """
+        self.indent = indent
+        self.include_content = include_content
+        self.repo_url = repo_url
+        self.repo_commit = repo_commit
+        self.repo_branch = repo_branch
+
+    def export(
+        self,
+        chunks: list[CodeChunk],
+        relationships: list[ChunkRelationship],
+        output: Path | io.IOBase,
+        metadata: ExportMetadata | None = None,
+    ) -> None:
+        """Export chunks and relationships to SemanticGraphBundle JSON.
+
+        Args:
+            chunks: List of code chunks to export as nodes
+            relationships: List of relationships to export as edges
+            output: Output file path or stream
+            metadata: Optional export metadata
+        """
+        bundle = self._build_bundle(chunks, relationships, metadata)
+        json_str = json.dumps(bundle, indent=self.indent, ensure_ascii=False)
+
+        if isinstance(output, str | Path):
+            Path(output).write_text(json_str, encoding="utf-8")
+        else:
+            output.write(json_str)
+
+    def export_streaming(
+        self,
+        chunk_iterator: Iterator[CodeChunk],
+        relationship_iterator: Iterator[ChunkRelationship],
+        output: Path | io.IOBase,
+    ) -> None:
+        """Export using iterators (collects all data due to JSON structure).
+
+        Note: SemanticGraphBundle requires complete structure, so streaming
+        collects all data before writing. For true streaming, use JSONL.
+
+        Args:
+            chunk_iterator: Iterator yielding code chunks
+            relationship_iterator: Iterator yielding relationships
+            output: Output file path or stream
+        """
+        chunks = list(chunk_iterator)
+        relationships = list(relationship_iterator)
+        self.export(chunks, relationships, output)
+
+    @staticmethod
+    def supports_format(fmt: ExportFormat) -> bool:
+        """Check if this exporter supports the given format.
+
+        Args:
+            fmt: Export format to check
+
+        Returns:
+            True if format is SEMANTIC_LENS
+        """
+        return fmt == ExportFormat.SEMANTIC_LENS
+
+    def get_schema(self) -> dict[str, Any]:
+        """Get the SemanticGraphBundle schema description.
+
+        Returns:
+            Schema definition dict
+        """
+        return {
+            "format": "semantic_lens",
+            "version": self.VERSION,
+            "spec": "SemanticGraphBundle",
+            "indent": self.indent,
+            "include_content": self.include_content,
+            "structure": {
+                "version": "Schema version string (v1.0)",
+                "generated_at": "ISO 8601 timestamp",
+                "repo": "Optional repository metadata",
+                "nodes": "Array of Node objects",
+                "edges": "Array of Edge objects",
+                "annotations": "Array of Annotation objects",
+                "patterns": "Array of PatternInstance objects",
+            },
+        }
+
+    def _build_bundle(
+        self,
+        chunks: list[CodeChunk],
+        relationships: list[ChunkRelationship],
+        metadata: ExportMetadata | None,
+    ) -> dict[str, Any]:
+        """Build the complete SemanticGraphBundle structure.
+
+        Args:
+            chunks: Code chunks to convert to nodes
+            relationships: Relationships to convert to edges
+            metadata: Optional export metadata
+
+        Returns:
+            Complete bundle dict ready for JSON serialization
+        """
+        # Build chunk_id -> node_id mapping for edge references
+        node_id_map: dict[str, str] = {}
+        nodes: list[dict[str, Any]] = []
+
+        for chunk in chunks:
+            node = self._chunk_to_node(chunk)
+            if node:  # Skip unmapped node types
+                nodes.append(node)
+                node_id_map[chunk.chunk_id] = node["node_id"]
+                if chunk.node_id:
+                    node_id_map[chunk.node_id] = node["node_id"]
+
+        edges = [
+            edge for edge in (
+                self._relationship_to_edge(rel, node_id_map)
+                for rel in relationships
+            )
+            if edge is not None
+        ]
+
+        annotations = self._build_annotations(chunks, node_id_map)
+
+        return {
+            "version": self.VERSION,
+            "generated_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+            "repo": self._build_repo(metadata),
+            "nodes": nodes,
+            "edges": edges,
+            "annotations": annotations,
+            "patterns": [],  # Empty - pattern detection is semantic-lens's job
+        }
+
+    def _chunk_to_node(self, chunk: CodeChunk) -> dict[str, Any] | None:
+        """Convert a CodeChunk to a SemanticGraphBundle Node.
+
+        Args:
+            chunk: The code chunk to convert
+
+        Returns:
+            Node dict or None if node_type cannot be mapped
+        """
+        kind = NODE_KIND_MAP.get(chunk.node_type)
+        if kind is None:
+            # Try lowercase matching
+            kind = NODE_KIND_MAP.get(chunk.node_type.lower())
+        if kind is None:
+            # Skip unknown node types (e.g., comments, expressions)
+            return None
+
+        # Generate stable node_id (minimum 8 chars required)
+        node_id = chunk.node_id or chunk.chunk_id
+        if len(node_id) < 8:
+            node_id = f"{node_id}_{uuid.uuid4().hex[:8]}"
+
+        # Extract name from qualified_route or parent_context
+        name = self._extract_name(chunk)
+
+        node: dict[str, Any] = {
+            "node_id": node_id,
+            "kind": kind,
+            "name": name,
+            "language": chunk.language,
+            "file": chunk.file_path,
+            "span": [chunk.byte_start, chunk.byte_end],
+        }
+
+        # Optional fields
+        if chunk.parent_chunk_id:
+            node["parent"] = chunk.parent_chunk_id
+
+        if chunk.qualified_route:
+            node["route"] = "::".join(chunk.qualified_route)
+
+        # Extract visibility from metadata if available
+        visibility = chunk.metadata.get("visibility")
+        if visibility in ("public", "protected", "private"):
+            node["visibility"] = visibility
+        else:
+            node["visibility"] = "unknown"
+
+        # Extract signature from metadata if available
+        signature = chunk.metadata.get("signature")
+        if signature:
+            node["signature"] = signature
+
+        return node
+
+    def _relationship_to_edge(
+        self,
+        rel: ChunkRelationship,
+        node_id_map: dict[str, str],
+    ) -> dict[str, Any] | None:
+        """Convert a ChunkRelationship to a SemanticGraphBundle Edge.
+
+        Args:
+            rel: The relationship to convert
+            node_id_map: Mapping from chunk_id to node_id
+
+        Returns:
+            Edge dict or None if relationship cannot be mapped
+        """
+        kind = EDGE_KIND_MAP.get(rel.relationship_type)
+        if kind is None:
+            return None
+
+        # Resolve source and destination node IDs
+        src = node_id_map.get(rel.source_chunk_id, rel.source_chunk_id)
+        dst = node_id_map.get(rel.target_chunk_id, rel.target_chunk_id)
+
+        # Skip edges to unmapped nodes
+        if src not in node_id_map.values() and src == rel.source_chunk_id:
+            return None
+        if dst not in node_id_map.values() and dst == rel.target_chunk_id:
+            return None
+
+        # Generate edge_id (minimum 8 chars required)
+        edge_id = f"e_{uuid.uuid4().hex[:12]}"
+
+        # Extract confidence from metadata or default to 1.0
+        confidence = 1.0
+        if rel.metadata and "confidence" in rel.metadata:
+            confidence = float(rel.metadata["confidence"])
+
+        edge: dict[str, Any] = {
+            "edge_id": edge_id,
+            "kind": kind,
+            "src": src,
+            "dst": dst,
+            "confidence": confidence,
+            "evidence": ["chunker"],  # Evidence source
+        }
+
+        # Include relationship metadata if present
+        if rel.metadata:
+            edge["meta"] = {
+                k: v for k, v in rel.metadata.items()
+                if k != "confidence"  # Already used above
+            }
+
+        return edge
+
+    def _build_annotations(
+        self,
+        chunks: list[CodeChunk],
+        node_id_map: dict[str, str],
+    ) -> list[dict[str, Any]]:
+        """Build annotations from chunk metadata.
+
+        Args:
+            chunks: Code chunks with potential metadata
+            node_id_map: Mapping from chunk_id to node_id
+
+        Returns:
+            List of Annotation dicts
+        """
+        annotations = []
+
+        for chunk in chunks:
+            node_id = node_id_map.get(chunk.chunk_id)
+            if not node_id:
+                continue
+
+            tags = []
+            kv: dict[str, Any] = {}
+
+            # Add node_type as tag
+            tags.append(f"type:{chunk.node_type}")
+
+            # Include content as annotation if requested
+            if self.include_content and chunk.content:
+                kv["content_lines"] = chunk.end_line - chunk.start_line + 1
+
+            # Extract tags from metadata
+            if chunk.metadata:
+                if "tags" in chunk.metadata:
+                    tags.extend(chunk.metadata["tags"])
+                # Copy select metadata to kv
+                for key in ("complexity", "lines", "tokens"):
+                    if key in chunk.metadata:
+                        kv[key] = chunk.metadata[key]
+
+            if tags or kv:
+                annotation: dict[str, Any] = {
+                    "target_id": node_id,
+                    "tags": tags,
+                }
+                if kv:
+                    annotation["kv"] = kv
+                annotations.append(annotation)
+
+        return annotations
+
+    def _build_repo(
+        self,
+        metadata: ExportMetadata | None,
+    ) -> dict[str, str] | None:
+        """Build repository metadata section.
+
+        Args:
+            metadata: Export metadata potentially containing repo info
+
+        Returns:
+            Repo dict or None if no repo info available
+        """
+        # Use explicit repo settings if provided
+        if self.repo_url and self.repo_commit:
+            repo = {
+                "url": self.repo_url,
+                "commit": self.repo_commit,
+            }
+            if self.repo_branch:
+                repo["branch"] = self.repo_branch
+            return repo
+
+        # Try to extract from export metadata
+        if metadata and metadata.source_files:
+            # Generate placeholder repo info from source files
+            return None  # No repo info available
+
+        return None
+
+    def _extract_name(self, chunk: CodeChunk) -> str:
+        """Extract the symbol name from a chunk.
+
+        Args:
+            chunk: Code chunk to extract name from
+
+        Returns:
+            Symbol name or fallback
+        """
+        # Try qualified_route first (last segment is the name)
+        if chunk.qualified_route:
+            last = chunk.qualified_route[-1]
+            # Format is "node_type:name" or just "name"
+            if ":" in last:
+                return last.split(":", 1)[1]
+            return last
+
+        # Try parent_context
+        if chunk.parent_context:
+            # parent_context often contains the name
+            parts = chunk.parent_context.split(".")
+            if parts:
+                return parts[-1]
+
+        # Try metadata
+        if "name" in chunk.metadata:
+            return str(chunk.metadata["name"])
+        if "symbol" in chunk.metadata:
+            return str(chunk.metadata["symbol"])
+
+        # Fallback to node_type with line number
+        return f"{chunk.node_type}@{chunk.start_line}"

--- a/chunker/export/structured_exporter.py
+++ b/chunker/export/structured_exporter.py
@@ -170,6 +170,7 @@ class StructuredExportOrchestrator(StructuredExporter):
                 ".sqlite3": ExportFormat.SQLITE,
                 ".cypher": ExportFormat.NEO4J,
                 ".cql": ExportFormat.NEO4J,
+                ".slb": ExportFormat.SEMANTIC_LENS,
             }
             if ext in format_map:
                 return format_map[ext]

--- a/chunker/interfaces/export.py
+++ b/chunker/interfaces/export.py
@@ -25,6 +25,7 @@ class ExportFormat(Enum):
     DOT = "dot"
     SQLITE = "sqlite"
     POSTGRESQL = "postgresql"
+    SEMANTIC_LENS = "semantic_lens"
 
 
 class RelationshipType(Enum):

--- a/docs/export-formats.md
+++ b/docs/export-formats.md
@@ -1031,6 +1031,114 @@ def create_beam_pipeline(input_files, language):
         )
 ```
 
+## SemanticGraphBundle (semantic-lens)
+
+Export to SemanticGraphBundle format for visualization in [semantic-lens](https://github.com/semantic-lens/semantic-lens), a code analysis and visualization platform.
+
+### File Extensions
+
+- `.slb` - SemanticLens Bundle (primary extension)
+
+### Usage
+
+```python
+from chunker.export import SemanticLensExporter
+
+exporter = SemanticLensExporter(
+    indent=2,                                    # JSON indentation (None for compact)
+    include_content=False,                       # Include source code in annotations
+    repo_url="https://github.com/org/repo",     # Optional repo metadata
+    repo_commit="abc1234",                       # Optional commit hash
+    repo_branch="main",                          # Optional branch
+)
+
+exporter.export(chunks, relationships, "output.slb")
+```
+
+### Output Structure
+
+```json
+{
+  "version": "v1.0",
+  "generated_at": "2024-01-01T00:00:00Z",
+  "repo": {
+    "url": "https://github.com/org/repo",
+    "commit": "abc1234",
+    "branch": "main"
+  },
+  "nodes": [
+    {
+      "node_id": "abc12345678",
+      "kind": "class",
+      "name": "UserService",
+      "language": "typescript",
+      "file": "src/user.ts",
+      "span": [0, 1000],
+      "visibility": "public",
+      "route": "module:user::class_definition:UserService"
+    }
+  ],
+  "edges": [
+    {
+      "edge_id": "e_abc12345678",
+      "kind": "calls",
+      "src": "method_abc",
+      "dst": "function_def",
+      "confidence": 0.95,
+      "evidence": ["chunker"]
+    }
+  ],
+  "annotations": [
+    {
+      "target_id": "abc12345678",
+      "tags": ["type:class_definition"]
+    }
+  ],
+  "patterns": []
+}
+```
+
+### Node Kind Mapping
+
+The following treesitter-chunker node types are mapped to semantic-lens node kinds:
+
+| treesitter-chunker | semantic-lens |
+|-------------------|---------------|
+| class_definition, class_declaration | class |
+| function_definition, function_declaration, arrow_function | function |
+| method_definition, method_declaration | method |
+| interface_declaration, interface_definition | interface |
+| trait_definition, trait_declaration | trait |
+| field_definition, field_declaration | field |
+| property_definition, property_declaration, property_signature | property |
+| module | module |
+| lexical_declaration, variable_declaration | property |
+| type_alias_declaration | interface |
+| enum_declaration | class |
+
+### Edge Kind Mapping
+
+| RelationshipType | semantic-lens |
+|-----------------|---------------|
+| CALLS | calls |
+| IMPORTS | imports |
+| INHERITS | inherits |
+| IMPLEMENTS | implements |
+| DEFINES, HAS_METHOD, PARENT_CHILD | defines |
+| USES, REFERENCES, DEPENDS_ON | uses |
+
+### Integration with semantic-lens
+
+After exporting, use the bundle with semantic-lens:
+
+```bash
+# Start semantic-lens visualization server
+cd /path/to/semantic-lens
+node dist/cli/index.js serve --port 3000 --bundle path/to/output.slb
+
+# Open http://localhost:3000 in browser
+```
+
 ## See Also
 
 - [API Reference](api-reference.md) - Export API documentation

--- a/tests/test_semantic_lens_export.py
+++ b/tests/test_semantic_lens_export.py
@@ -1,0 +1,475 @@
+"""Tests for SemanticLensExporter."""
+
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+
+import pytest
+
+from chunker.export.formats.semantic_lens import (
+    EDGE_KIND_MAP,
+    NODE_KIND_MAP,
+    SemanticLensExporter,
+)
+from chunker.interfaces.export import (
+    ChunkRelationship,
+    ExportFormat,
+    RelationshipType,
+)
+from chunker.types import CodeChunk
+
+
+@pytest.fixture
+def sample_chunks() -> list[CodeChunk]:
+    """Create sample chunks for testing."""
+    return [
+        CodeChunk(
+            language="typescript",
+            file_path="src/user.ts",
+            node_type="class_definition",
+            start_line=1,
+            end_line=50,
+            byte_start=0,
+            byte_end=1000,
+            parent_context="UserService",
+            content="class UserService { ... }",
+            qualified_route=["module:user", "class_definition:UserService"],
+            metadata={"visibility": "public"},
+        ),
+        CodeChunk(
+            language="typescript",
+            file_path="src/user.ts",
+            node_type="method_definition",
+            start_line=10,
+            end_line=20,
+            byte_start=100,
+            byte_end=300,
+            parent_context="UserService.getUser",
+            content="async getUser(id: string) { ... }",
+            qualified_route=[
+                "module:user",
+                "class_definition:UserService",
+                "method_definition:getUser",
+            ],
+            metadata={"visibility": "public", "signature": "(id: string) => Promise<User>"},
+        ),
+    ]
+
+
+@pytest.fixture
+def sample_relationships(sample_chunks: list[CodeChunk]) -> list[ChunkRelationship]:
+    """Create sample relationships for testing."""
+    return [
+        ChunkRelationship(
+            source_chunk_id=sample_chunks[0].chunk_id,
+            target_chunk_id=sample_chunks[1].chunk_id,
+            relationship_type=RelationshipType.DEFINES,
+            metadata={"confidence": 1.0},
+        ),
+        ChunkRelationship(
+            source_chunk_id=sample_chunks[1].chunk_id,
+            target_chunk_id=sample_chunks[0].chunk_id,
+            relationship_type=RelationshipType.CALLS,
+            metadata=None,
+        ),
+    ]
+
+
+class TestSemanticLensExporter:
+    """Tests for SemanticLensExporter class."""
+
+    def test_supports_format(self):
+        """Test format support check."""
+        assert SemanticLensExporter.supports_format(ExportFormat.SEMANTIC_LENS)
+        assert not SemanticLensExporter.supports_format(ExportFormat.JSON)
+        assert not SemanticLensExporter.supports_format(ExportFormat.GRAPHML)
+
+    def test_get_schema(self):
+        """Test schema retrieval."""
+        exporter = SemanticLensExporter()
+        schema = exporter.get_schema()
+
+        assert schema["format"] == "semantic_lens"
+        assert schema["version"] == "v1.0"
+        assert "structure" in schema
+        assert "nodes" in schema["structure"]
+        assert "edges" in schema["structure"]
+
+    def test_export_basic(self, sample_chunks, sample_relationships):
+        """Test basic export to stream."""
+        exporter = SemanticLensExporter()
+        output = io.StringIO()
+
+        exporter.export(sample_chunks, sample_relationships, output)
+
+        output.seek(0)
+        bundle = json.load(output)
+
+        assert bundle["version"] == "v1.0"
+        assert "generated_at" in bundle
+        assert bundle["generated_at"].endswith("Z")
+        assert len(bundle["nodes"]) == 2
+        assert len(bundle["edges"]) >= 1
+        assert "annotations" in bundle
+        assert "patterns" in bundle
+        assert bundle["patterns"] == []
+
+    def test_export_to_file(self, sample_chunks, sample_relationships, tmp_path):
+        """Test export to file path."""
+        exporter = SemanticLensExporter()
+        output_file = tmp_path / "output.slb"
+
+        exporter.export(sample_chunks, sample_relationships, output_file)
+
+        assert output_file.exists()
+        bundle = json.loads(output_file.read_text())
+        assert bundle["version"] == "v1.0"
+
+    def test_node_mapping(self, sample_chunks):
+        """Test chunk to node conversion."""
+        exporter = SemanticLensExporter()
+        output = io.StringIO()
+
+        exporter.export(sample_chunks, [], output)
+
+        output.seek(0)
+        bundle = json.load(output)
+
+        # Check class node
+        class_node = next(n for n in bundle["nodes"] if n["kind"] == "class")
+        assert class_node["name"] == "UserService"
+        assert class_node["language"] == "typescript"
+        assert class_node["file"] == "src/user.ts"
+        assert class_node["visibility"] == "public"
+        assert len(class_node["node_id"]) >= 8
+
+        # Check method node
+        method_node = next(n for n in bundle["nodes"] if n["kind"] == "method")
+        assert method_node["name"] == "getUser"
+        assert method_node["signature"] == "(id: string) => Promise<User>"
+
+    def test_edge_mapping(self, sample_chunks, sample_relationships):
+        """Test relationship to edge conversion."""
+        exporter = SemanticLensExporter()
+        output = io.StringIO()
+
+        exporter.export(sample_chunks, sample_relationships, output)
+
+        output.seek(0)
+        bundle = json.load(output)
+
+        edges = bundle["edges"]
+        edge_kinds = {e["kind"] for e in edges}
+
+        assert "defines" in edge_kinds or "calls" in edge_kinds
+        for edge in edges:
+            assert len(edge["edge_id"]) >= 8
+            assert 0.0 <= edge["confidence"] <= 1.0
+            assert "chunker" in edge["evidence"]
+
+    def test_all_node_kinds_mapped(self):
+        """Verify all mapped node types produce valid kinds."""
+        for node_type, kind in NODE_KIND_MAP.items():
+            assert kind in (
+                "module", "class", "interface", "trait",
+                "function", "method", "field", "property",
+            ), f"Invalid kind '{kind}' for node_type '{node_type}'"
+
+    def test_all_edge_kinds_mapped(self):
+        """Verify all mapped relationship types produce valid kinds."""
+        for rel_type, kind in EDGE_KIND_MAP.items():
+            assert kind in (
+                "defines", "imports", "calls", "inherits",
+                "implements", "uses", "reads", "writes", "throws",
+            ), f"Invalid kind '{kind}' for relationship '{rel_type}'"
+
+    def test_repo_metadata(self, sample_chunks):
+        """Test repository metadata inclusion."""
+        exporter = SemanticLensExporter(
+            repo_url="https://github.com/example/project",
+            repo_commit="abc1234",
+            repo_branch="main",
+        )
+        output = io.StringIO()
+
+        exporter.export(sample_chunks, [], output)
+
+        output.seek(0)
+        bundle = json.load(output)
+
+        assert bundle["repo"]["url"] == "https://github.com/example/project"
+        assert bundle["repo"]["commit"] == "abc1234"
+        assert bundle["repo"]["branch"] == "main"
+
+    def test_export_streaming(self, sample_chunks, sample_relationships):
+        """Test streaming export (collects all due to JSON structure)."""
+        exporter = SemanticLensExporter()
+        output = io.StringIO()
+
+        exporter.export_streaming(
+            iter(sample_chunks),
+            iter(sample_relationships),
+            output,
+        )
+
+        output.seek(0)
+        bundle = json.load(output)
+        assert len(bundle["nodes"]) == 2
+
+    def test_compact_output(self, sample_chunks):
+        """Test compact (no indent) output."""
+        exporter = SemanticLensExporter(indent=None)
+        output = io.StringIO()
+
+        exporter.export(sample_chunks, [], output)
+
+        output.seek(0)
+        content = output.read()
+        assert "\n" not in content.strip()
+
+    def test_empty_export(self):
+        """Test export with no chunks or relationships."""
+        exporter = SemanticLensExporter()
+        output = io.StringIO()
+
+        exporter.export([], [], output)
+
+        output.seek(0)
+        bundle = json.load(output)
+
+        assert bundle["nodes"] == []
+        assert bundle["edges"] == []
+        assert bundle["patterns"] == []
+
+    def test_unknown_node_type_skipped(self):
+        """Test that unknown node types are skipped."""
+        chunk = CodeChunk(
+            language="typescript",
+            file_path="src/test.ts",
+            node_type="comment",  # Not in NODE_KIND_MAP
+            start_line=1,
+            end_line=1,
+            byte_start=0,
+            byte_end=50,
+            parent_context="",
+            content="// comment",
+        )
+        exporter = SemanticLensExporter()
+        output = io.StringIO()
+
+        exporter.export([chunk], [], output)
+
+        output.seek(0)
+        bundle = json.load(output)
+        assert bundle["nodes"] == []
+
+    def test_annotations_created(self, sample_chunks):
+        """Test that annotations are created from metadata."""
+        exporter = SemanticLensExporter()
+        output = io.StringIO()
+
+        exporter.export(sample_chunks, [], output)
+
+        output.seek(0)
+        bundle = json.load(output)
+
+        assert len(bundle["annotations"]) > 0
+        for annotation in bundle["annotations"]:
+            assert "target_id" in annotation
+            assert "tags" in annotation
+
+    def test_unicode_handling(self):
+        """Test handling of Unicode in content and names."""
+        chunk = CodeChunk(
+            language="typescript",
+            file_path="src/emoji.ts",
+            node_type="function_definition",
+            start_line=1,
+            end_line=5,
+            byte_start=0,
+            byte_end=100,
+            parent_context="getUserName",
+            content='function getUserName() { return "名前"; }',
+            qualified_route=["function_definition:getUserName"],
+        )
+        exporter = SemanticLensExporter()
+        output = io.StringIO()
+
+        exporter.export([chunk], [], output)
+
+        output.seek(0)
+        bundle = json.load(output)
+
+        assert len(bundle["nodes"]) == 1
+        assert bundle["nodes"][0]["name"] == "getUserName"
+
+    def test_span_format(self, sample_chunks):
+        """Test that span is exported as [byte_start, byte_end] array."""
+        exporter = SemanticLensExporter()
+        output = io.StringIO()
+
+        exporter.export(sample_chunks, [], output)
+
+        output.seek(0)
+        bundle = json.load(output)
+
+        for node in bundle["nodes"]:
+            assert isinstance(node["span"], list)
+            assert len(node["span"]) == 2
+            assert isinstance(node["span"][0], int)
+            assert isinstance(node["span"][1], int)
+
+    def test_route_format(self, sample_chunks):
+        """Test that route is joined with :: separator."""
+        exporter = SemanticLensExporter()
+        output = io.StringIO()
+
+        exporter.export(sample_chunks, [], output)
+
+        output.seek(0)
+        bundle = json.load(output)
+
+        class_node = next(n for n in bundle["nodes"] if n["kind"] == "class")
+        assert "::" in class_node["route"]
+        assert class_node["route"] == "module:user::class_definition:UserService"
+
+    def test_name_extraction_from_qualified_route(self):
+        """Test name extraction when qualified_route has type:name format."""
+        chunk = CodeChunk(
+            language="typescript",
+            file_path="src/test.ts",
+            node_type="function_definition",
+            start_line=1,
+            end_line=5,
+            byte_start=0,
+            byte_end=100,
+            parent_context="",
+            content="function myFunc() {}",
+            qualified_route=["function_definition:myFunc"],
+        )
+        exporter = SemanticLensExporter()
+        output = io.StringIO()
+
+        exporter.export([chunk], [], output)
+
+        output.seek(0)
+        bundle = json.load(output)
+
+        assert bundle["nodes"][0]["name"] == "myFunc"
+
+    def test_name_extraction_fallback_to_parent_context(self):
+        """Test name extraction fallback to parent_context."""
+        chunk = CodeChunk(
+            language="typescript",
+            file_path="src/test.ts",
+            node_type="function_definition",
+            start_line=1,
+            end_line=5,
+            byte_start=0,
+            byte_end=100,
+            parent_context="module.myFunction",
+            content="function myFunction() {}",
+            qualified_route=[],
+        )
+        exporter = SemanticLensExporter()
+        output = io.StringIO()
+
+        exporter.export([chunk], [], output)
+
+        output.seek(0)
+        bundle = json.load(output)
+
+        assert bundle["nodes"][0]["name"] == "myFunction"
+
+    def test_visibility_unknown_default(self):
+        """Test that missing visibility defaults to unknown."""
+        chunk = CodeChunk(
+            language="typescript",
+            file_path="src/test.ts",
+            node_type="function_definition",
+            start_line=1,
+            end_line=5,
+            byte_start=0,
+            byte_end=100,
+            parent_context="myFunc",
+            content="function myFunc() {}",
+            metadata={},  # No visibility
+        )
+        exporter = SemanticLensExporter()
+        output = io.StringIO()
+
+        exporter.export([chunk], [], output)
+
+        output.seek(0)
+        bundle = json.load(output)
+
+        assert bundle["nodes"][0]["visibility"] == "unknown"
+
+    def test_edge_confidence_from_metadata(self):
+        """Test that edge confidence is extracted from relationship metadata."""
+        chunk1 = CodeChunk(
+            language="typescript",
+            file_path="src/a.ts",
+            node_type="function_definition",
+            start_line=1,
+            end_line=5,
+            byte_start=0,
+            byte_end=100,
+            parent_context="funcA",
+            content="function funcA() {}",
+        )
+        chunk2 = CodeChunk(
+            language="typescript",
+            file_path="src/b.ts",
+            node_type="function_definition",
+            start_line=1,
+            end_line=5,
+            byte_start=0,
+            byte_end=100,
+            parent_context="funcB",
+            content="function funcB() {}",
+        )
+        rel = ChunkRelationship(
+            source_chunk_id=chunk1.chunk_id,
+            target_chunk_id=chunk2.chunk_id,
+            relationship_type=RelationshipType.CALLS,
+            metadata={"confidence": 0.85},
+        )
+
+        exporter = SemanticLensExporter()
+        output = io.StringIO()
+
+        exporter.export([chunk1, chunk2], [rel], output)
+
+        output.seek(0)
+        bundle = json.load(output)
+
+        assert len(bundle["edges"]) == 1
+        assert bundle["edges"][0]["confidence"] == 0.85
+
+    def test_include_content_annotation(self):
+        """Test that content_lines is added when include_content=True."""
+        chunk = CodeChunk(
+            language="typescript",
+            file_path="src/test.ts",
+            node_type="function_definition",
+            start_line=1,
+            end_line=10,
+            byte_start=0,
+            byte_end=200,
+            parent_context="myFunc",
+            content="function myFunc() {\n  // many lines\n}",
+        )
+        exporter = SemanticLensExporter(include_content=True)
+        output = io.StringIO()
+
+        exporter.export([chunk], [], output)
+
+        output.seek(0)
+        bundle = json.load(output)
+
+        annotation = bundle["annotations"][0]
+        assert "kv" in annotation
+        assert annotation["kv"]["content_lines"] == 10  # end_line - start_line + 1


### PR DESCRIPTION
## Summary

Add `SemanticLensExporter` to export code chunks and relationships to the SemanticGraphBundle JSON format, enabling visualization in [semantic-lens](https://github.com/Consiliency/semantic-lens).

- Add `SEMANTIC_LENS` enum value to `ExportFormat`
- Create `SemanticLensExporter` class with full node/edge mapping
- Support `.slb` file extension auto-detection
- Add comprehensive test suite (22 tests)
- Document format in `docs/export-formats.md`

### Node Kind Mapping

| treesitter-chunker | semantic-lens |
|-------------------|---------------|
| class_definition | class |
| function_definition | function |
| method_definition | method |
| interface_declaration | interface |
| module | module |
| trait_definition | trait |
| field_definition | field |
| property_definition | property |

### Edge Kind Mapping

| RelationshipType | semantic-lens |
|-----------------|---------------|
| CALLS | calls |
| IMPORTS | imports |
| INHERITS | inherits |
| IMPLEMENTS | implements |
| DEFINES | defines |
| USES | uses |

## Test plan

- [x] All 22 new tests pass (`pytest tests/test_semantic_lens_export.py`)
- [x] Generated sample `.slb` bundle from navblue-extension
- [x] Bundle validates in semantic-lens (`node dist/cli/index.js validate`)
- [x] Visualization renders correctly in semantic-lens view service

🤖 Generated with [Claude Code](https://claude.com/claude-code)