### PR TITLE
Add interface boundary spec, roadmap, and readiness assessment docs

### DIFF
--- a/docs/agent-interface-readiness.md
+++ b/docs/agent-interface-readiness.md
@@ -1,0 +1,166 @@
+# Agent Interface Ownership Readiness (Repository Assessment)
+
+> This document is a readiness assessment.
+> The implementation-facing specification lives in:
+> `docs/interface-boundary-spec.md`.
+> The execution plan lives in:
+> `docs/interface-boundary-roadmap.md`.
+
+This document evaluates how ready `treesitter-chunker` is to support **agent-oriented code surface ownership** enforced via **AST-derived boundaries**.
+
+## Bottom line
+
+This repository is a strong foundation for an AST-first ownership system, but it is currently optimized for chunking, metadata enrichment, and relationship inference rather than strict policy enforcement. The primitives you need already exist (stable IDs, symbol extraction, relationship graphs, multi-language adapters), while policy/runtime guardrails are still missing.
+
+## Should this live in this repo or above it?
+
+Recommendation: keep ownership-policy enforcement in a **separate orchestrator project** and use `treesitter-chunker` as a dependency.
+
+Why:
+
+- This package's primary contract is extraction/chunking and language support.
+- Ownership policy and multi-agent authorization is a higher-level orchestration concern.
+- Keeping policy external lets you iterate policy rules and governance models without coupling them to parser/chunker release cadence.
+
+Reasonable split:
+
+- `treesitter-chunker` owns AST parsing, symbol extraction, metadata normalization, and graph export.
+- The orchestrator owns agent manifests, policy evaluation, patch validation, and allow/reject enforcement.
+
+## What is already in place
+
+### 1) AST ingestion and multi-language coverage
+
+- Core processing is Tree-sitter-based and language-aware, with dynamic language discovery and plugin support.
+- The architecture is explicitly modular around parser management, chunk extraction, and language plugins.
+
+**Implication for ownership model:** You already have a production AST ingestion plane suitable for deterministic, repeatable extraction.
+
+### 2) Stable identity primitives
+
+- `CodeChunk` includes `node_id`, `file_id`, `symbol_id`, `qualified_route`, and `definition_id`.
+- `definition_id` is explicitly content-insensitive and derived from structural route, which is exactly the kind of stability you need for ownership boundaries across edits.
+
+**Implication for ownership model:** You can assign policy to structural identities instead of byte ranges or text diffs.
+
+### 3) Language-agnostic retrieval metadata normalization
+
+- The core metadata pipeline normalizes kind/symbol/qualified_name/semantic_path and dependency-style fields in a language-agnostic shape.
+
+**Implication for ownership model:** This is already a near-IR substrate. You can promote this retrieval metadata into a formal ownership IR with fewer transformations.
+
+### 4) Existing symbol graph extraction
+
+- `extract_symbol_graph()` already builds a graph-like structure with symbols, internal/external relationships, imports/dependencies/calls, and per-symbol lookup records.
+- Symbol IDs currently combine module and qualified names where available.
+
+**Implication for ownership model:** The repo already has an initial “program graph projection” that can seed ownership checks and policy evaluation.
+
+### 5) Export pathway for graph consumers
+
+- Semantic lens export maps chunk node kinds and relationship kinds into a normalized bundle model.
+
+**Implication for ownership model:** You can either keep policy local or export to an external policy/graph engine without inventing a fresh interchange format from scratch.
+
+## Gaps that block deterministic enforcement today
+
+### 1) No first-class ownership policy engine
+
+There is no built-in concept of:
+
+- agent-to-symbol ownership mapping,
+- allowed/forbidden cross-boundary calls,
+- reject/allow decisions over proposed code edits.
+
+### 2) Relationship inference has heuristic edges
+
+Current relationship resolution includes tokenized candidate matching and unique-name heuristics. That is useful for discovery, but policy enforcement should avoid heuristic ambiguity at decision time.
+
+### 3) Limited semantic guarantees
+
+Tree-sitter coverage is strong, but this repo does not currently provide full type/binding resolution for authoritative call-target disambiguation in all languages.
+
+### 4) No patch-to-IR validator workflow
+
+There is no built-in gate that:
+
+1. parses a patch,
+2. maps edits to structural symbol identities,
+3. enforces ownership policy,
+4. returns machine-verifiable allow/reject outcomes.
+
+## Recommended architecture using this repo as a dependency
+
+Use `treesitter-chunker` as the **front-end extractor dependency**, then add a slim policy service layer:
+
+1. **Ingest** with `chunk_file(..., extract_metadata=True, include_retrieval_metadata=True)` and/or `extract_symbol_graph()`.
+2. **Normalize to ownership IR** using stable structural IDs (`definition_id` preferred, fallback to module+qualified_name).
+3. **Attach policy** via a separate manifest (e.g., `agent_policy.yaml`) mapping agent scopes and allowed edge types.
+4. **Validate edits** by parsing changed files and reconciling changed definitions against policy.
+5. **Fail closed** for unresolved symbol mappings in enforcement mode (log separately for triage).
+
+## Suggested near-term implementation phases
+
+### Phase 1: Deterministic ownership MVP
+
+- Define ownership IR schema from existing chunk metadata + symbol graph output.
+- Use `definition_id` and `qualified_name` as canonical node keys.
+- Implement read-only report mode (`violations` list only).
+
+### Phase 2: Pre-merge enforcement mode
+
+- Add strict policy checker that fails when modified symbols are outside agent scope.
+- Only allow relationship checks when target resolution is deterministic; otherwise classify as unresolved and fail closed (configurable).
+
+### Phase 3: Optional semantic upgrades
+
+- Add language-specific semantic resolvers where needed for high-confidence edge disambiguation (LSP/type-checker augmentation).
+
+## Practical readiness score
+
+- **Extractor readiness:** High
+- **IR readiness:** Medium-high (close, not formalized)
+- **Policy enforcement readiness:** Low-medium (needs new module)
+- **Cross-language viability:** Medium-high (with per-language adapters)
+
+Overall: **good dependency choice** for bootstrapping an AST-governed agent ownership system, as long as you plan to build a dedicated policy/enforcement layer on top.
+
+## Optimization gaps to fill in `treesitter-chunker` itself
+
+If the goal is to make this package maximally ready as a dependency for deterministic agent systems, these are the highest-leverage improvements:
+
+### 1) Determinism hardening for symbol/edge resolution
+
+- Add a strict mode that disallows heuristic fallback in relationship resolution when targets are ambiguous.
+- Emit explicit resolution status (`resolved`, `ambiguous`, `unresolved`) for every edge candidate.
+- Support fail-closed exports for downstream policy engines.
+
+### 2) First-class IR export mode
+
+- Promote current normalized metadata + symbol graph into a documented, versioned interface IR schema.
+- Add schema versioning and compatibility checks for downstream consumers.
+- Guarantee canonical ordering of nodes/edges in output for reproducible diffs.
+
+### 3) Incremental graph recomputation
+
+- Recompute symbols/relationships only for changed files + impacted neighbors.
+- Persist index artifacts keyed by file hash + grammar version.
+- Add a “cold vs warm graph build” benchmark target in CI smoke tooling.
+
+### 4) Stronger cross-language extraction contracts
+
+- Tighten per-language conformance tests for `kind`, `qualified_name`, signatures, imports/dependencies/calls.
+- Require extractor contract fixtures for new languages before merge.
+- Add parity score reporting to prevent regressions in less-common grammars.
+
+### 5) Better observability for large-repo runs
+
+- Add timing spans around parse, metadata normalization, graph assembly, and resolution passes.
+- Emit counters for skipped files, parse failures, unresolved edges, and ambiguous edges.
+- Provide structured run summaries suitable for policy pipeline SLIs/SLOs.
+
+### 6) Optional semantic augmentation hooks
+
+- Define extension points for plugging in LSP/type-checker resolvers without changing core extraction APIs.
+- Preserve a strict separation: syntactic baseline always available, semantic enrichment opt-in.
+- Record provenance on enriched edges so downstream policy can choose trust level.

--- a/docs/interface-boundary-roadmap.md
+++ b/docs/interface-boundary-roadmap.md
@@ -1,0 +1,126 @@
+# Interface Boundary Parsing Roadmap (External Orchestrator + treesitter-chunker)
+
+This roadmap focuses only on boundary parsing and IR generation.
+
+## Milestone goals
+
+- **P0**: deterministic boundary extraction works end-to-end for core languages.
+- **P1**: scalability and quality hardening for medium/large repos.
+- **P2**: advanced semantics and ecosystem integration.
+
+---
+
+## P0 (2–3 weeks): Deterministic baseline
+
+### Outcomes
+
+- Generate canonical boundary IR for at least Python, TypeScript/JavaScript, and Go.
+- Reproducible outputs for identical repo snapshot + tool version.
+- Explicit edge resolution states (`resolved|ambiguous|unresolved`).
+
+### Work items
+
+1. **IR adapter layer**
+   - Build adapter from `chunk_file(...include_retrieval_metadata=True)` and `extract_symbol_graph()` output to spec IR.
+   - Implement canonical node/edge sorting and stable JSON serialization.
+
+2. **Boundary ID strategy**
+   - Implement precedence: `definition_id` → `module+qualified_name` → `node_id`.
+   - Add deterministic deduplication.
+
+3. **Strict mode implementation**
+   - No guessed edges in strict mode.
+   - Track ambiguous/unresolved edge counters.
+
+4. **Golden tests**
+   - Snapshot tests against fixture repos for deterministic output.
+   - Run same input twice and assert byte-identical output.
+
+### Exit criteria
+
+- Determinism tests pass in CI.
+- Spec compliance checklist is fully green for core languages.
+
+---
+
+## P1 (3–5 weeks): Throughput and resilience
+
+### Outcomes
+
+- Faster repeated runs on incremental commits.
+- Better diagnostics and quality metrics.
+- Broader language coverage without breaking determinism.
+
+### Work items
+
+1. **Incremental recomputation**
+   - Re-extract only changed files and impacted neighbors.
+   - Cache intermediate boundary records keyed by file hash.
+
+2. **Observability**
+   - Add structured timings: parse, normalization, graph assembly, serialization.
+   - Publish run summary counters and top failure buckets.
+
+3. **Conformance suite expansion**
+   - Add extractor conformance fixtures for additional languages.
+   - Add per-language parity dashboards for key fields (`kind`, `qualified_name`, signatures).
+
+4. **Robust failure handling**
+   - Continue on parse errors by default.
+   - Add `fail_fast` toggle for strict pipelines.
+
+### Exit criteria
+
+- Incremental mode demonstrates measurable speedup on fixture repos.
+- Diagnostics are sufficient to triage unresolved/ambiguous edge regressions.
+
+---
+
+## P2 (optional): Semantic enrichment hooks
+
+### Outcomes
+
+- Optional high-confidence enrichment of relationships where syntax-only extraction is insufficient.
+
+### Work items
+
+1. **Semantic plugin interface**
+   - Define hook points for LSP/type-checker enrichment.
+   - Preserve provenance and confidence metadata.
+
+2. **Trust-tiered edges**
+   - Mark each edge with `source=syntax|semantic` and confidence value.
+   - Keep strict mode defaults syntax-first.
+
+3. **Compatibility guarantees**
+   - Version IR schema and publish migration notes.
+
+### Exit criteria
+
+- Semantic enrichment is optional and cannot break baseline deterministic output.
+
+---
+
+## Suggested execution order (first 10 tasks)
+
+1. Implement IR schema + serializer.
+2. Implement ID precedence logic.
+3. Add deterministic sort + canonical JSON.
+4. Add strict/permissive resolution policy.
+5. Build first golden fixtures (3 languages).
+6. Add deterministic CI gate (double-run equivalence).
+7. Add structured metrics output.
+8. Implement cache key strategy.
+9. Add incremental recomputation.
+10. Expand language conformance fixtures.
+
+## Risk register
+
+- **Risk**: cross-language metadata inconsistencies.  
+  **Mitigation**: conformance fixtures + required-field validation.
+
+- **Risk**: heuristic drift causing non-deterministic edges.  
+  **Mitigation**: strict mode and explicit resolution states.
+
+- **Risk**: output churn due to schema evolution.  
+  **Mitigation**: versioned schema + migration policy.

--- a/docs/interface-boundary-spec.md
+++ b/docs/interface-boundary-spec.md
@@ -1,0 +1,151 @@
+# Interface Boundary Parsing Spec (for External Orchestrator Repo)
+
+## Purpose
+
+This specification defines how a separate orchestrator repository should derive deterministic **interface boundaries** from source code by using `treesitter-chunker` as a dependency.
+
+Scope in this spec is intentionally limited to parsing and boundary extraction. Agent policy, scheduling, and runtime orchestration are out of scope.
+
+## Normative Terms
+
+- **MUST**: required for compliance.
+- **SHOULD**: recommended unless a strong reason exists not to.
+- **MAY**: optional.
+
+## System Context
+
+The orchestrator:
+
+1. MUST call `chunk_file(..., extract_metadata=True, include_retrieval_metadata=True)` and/or `extract_symbol_graph()` from `treesitter-chunker`.
+2. MUST convert extractor output into a canonical Interface Boundary IR (defined below).
+3. MUST produce reproducible output for the same repo state + tool versions.
+
+## Inputs
+
+### Required inputs
+
+- Repository root path.
+- Commit SHA or equivalent content snapshot identifier.
+- Language selection mode:
+  - explicit language allowlist, or
+  - auto-detect through file extension mapping.
+
+### Optional inputs
+
+- Path include/exclude globs.
+- File size limits.
+- Maximum parse concurrency.
+- Strictness mode (`strict` | `permissive`).
+
+## Required extraction primitives from `treesitter-chunker`
+
+The orchestrator MUST consume these primitives where available:
+
+- structural identity: `definition_id`, `node_id`, `qualified_route`.
+- normalized metadata: `kind`, `symbol`, `qualified_name`, `parent_symbol`, `semantic_path`, `signature_text`.
+- graph context: symbols and relationships from `extract_symbol_graph()`.
+
+If `definition_id` is unavailable, fallback identity SHOULD be:
+
+1. `module + qualified_name`, then
+2. `node_id`.
+
+## Canonical Interface Boundary IR
+
+The orchestrator MUST emit a canonical JSON document with this structure:
+
+```json
+{
+  "schema_version": "v0.1",
+  "repo": {
+    "root": "...",
+    "commit": "..."
+  },
+  "nodes": [
+    {
+      "boundary_id": "...",
+      "kind": "module|class|interface|struct|trait|function|method",
+      "name": "...",
+      "qualified_name": "...",
+      "file": "...",
+      "line_start": 0,
+      "line_end": 0,
+      "language": "...",
+      "signature": "...",
+      "parent_boundary_id": "...",
+      "provenance": {
+        "definition_id": "...",
+        "node_id": "..."
+      }
+    }
+  ],
+  "edges": [
+    {
+      "from": "boundary_id",
+      "to": "boundary_id|external_ref",
+      "type": "imports|dependencies|calls",
+      "resolution": "resolved|ambiguous|unresolved",
+      "is_internal": true
+    }
+  ],
+  "stats": {
+    "files_processed": 0,
+    "nodes_total": 0,
+    "edges_total": 0,
+    "ambiguous_edges": 0,
+    "unresolved_edges": 0
+  }
+}
+```
+
+## Canonicalization rules
+
+To ensure deterministic output, the orchestrator MUST:
+
+1. sort `nodes` by `(file, line_start, kind, name, boundary_id)`.
+2. sort `edges` by `(from, to, type, resolution)`.
+3. emit UTF-8 JSON with stable key ordering.
+4. include `schema_version` and repo snapshot metadata.
+
+## Boundary derivation rules
+
+1. A boundary node MUST map to one extracted symbol-like unit (`module/class/interface/struct/trait/function/method`).
+2. `boundary_id` MUST prefer `definition_id` when present.
+3. If multiple extractor records map to one boundary candidate, deduplication MUST be deterministic and preserve first record by sorted order.
+4. Nodes with missing `name` and missing stable provenance MUST be dropped and counted as skipped.
+
+## Relationship resolution rules
+
+- In `strict` mode:
+  - ambiguous targets MUST remain `ambiguous` (no guessed target).
+  - unresolved targets MUST remain `unresolved`.
+- In `permissive` mode:
+  - heuristic fallback MAY be used, but original resolution state MUST be preserved in metadata.
+
+## Error handling and observability
+
+The orchestrator MUST output structured diagnostics:
+
+- parse failures by file/language,
+- skipped nodes with reason,
+- edge resolution summary,
+- extraction duration metrics.
+
+No single-file parse failure should terminate full-repo extraction unless configured `fail_fast=true`.
+
+## Compliance checklist (minimum)
+
+An implementation is compliant only if all are true:
+
+- [ ] Canonical IR shape is emitted with required fields.
+- [ ] Deterministic sorting/canonicalization is applied.
+- [ ] Boundary IDs use required precedence.
+- [ ] Edge resolution state is explicit.
+- [ ] Diagnostics include skipped/ambiguous/unresolved counts.
+
+## Out of scope
+
+- Agent ownership policy language.
+- Authorization decisions.
+- Patch apply/reject workflows.
+- Runtime autonomous agent execution.


### PR DESCRIPTION
### Motivation

- Provide a clear, consumable specification for deriving deterministic interface boundaries from `treesitter-chunker` output. 
- Capture a recommended execution roadmap and phased work items to move from extraction-first tooling to policy-ready boundary exports. 
- Surface current repository strengths and gaps with respect to agent-oriented ownership enforcement to guide an external orchestrator design.

### Description

- Add `docs/interface-boundary-spec.md` which defines the canonical Interface Boundary IR, canonicalization rules, required extractor primitives, and strict/permissive resolution behavior, including example JSON shape and rules that require use of `definition_id` when available. 
- Add `docs/interface-boundary-roadmap.md` which breaks work into P0/P1/P2 milestones, lists specific implementation tasks (IR adapter, ID precedence, strict mode, incremental recompute, observability, semantic hooks), and includes exit criteria and a risk register. 
- Add `docs/agent-interface-readiness.md` which assesses the repo readiness for agent-oriented ownership enforcement, enumerates existing capabilities (stable IDs, symbol graph, metadata normalization) and gaps (no policy engine, heuristic edges, no patch-to-IR validator), and recommends an orchestrator-based split plus near-term improvements for determinism and IR exports.

### Testing

- This is a documentation-only change so no unit or integration tests were modified. 
- Documentation linting and local docs build were run and completed successfully using `markdownlint` and the repository's docs build tooling. 
- CI will continue to validate repository tests as normal and no additional automated tests were added for these docs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e928996ab0832db59d89711b87ce69)