### PR TITLE
P1: adopt canon v1 — fix boundary-IR determinism (BUG-1/1b/2/3/4)

### DIFF
--- a/chunker/boundary/__init__.py
+++ b/chunker/boundary/__init__.py
@@ -2,7 +2,13 @@
 
 from .adapter import extract_boundary_ir
 from .identity import select_node_identity
-from .serialization import dumps_boundary_ir
+from .serialization import (
+    canonicalize_boundary_ir,
+    canonicalize_for_parity,
+    canonicalize_for_parity_bytes,
+    dumps_boundary_ir,
+    parity_digest,
+)
 from .semantic import SemanticEdge, SemanticResolver, SemanticResolverContext
 from .types import (
     BOUNDARY_CACHE_EXCLUDED_OPTION_FIELDS,
@@ -47,7 +53,11 @@ __all__ = [
     "SemanticResolver",
     "SemanticResolverContext",
     "TIMING_KEYS",
+    "canonicalize_boundary_ir",
+    "canonicalize_for_parity",
+    "canonicalize_for_parity_bytes",
     "dumps_boundary_ir",
     "extract_boundary_ir",
+    "parity_digest",
     "select_node_identity",
 ]

--- a/chunker/boundary/_canon.py
+++ b/chunker/boundary/_canon.py
@@ -1,0 +1,249 @@
+"""Vendored copy of canon v1 — the spec canonical serialization contract (S1).
+
+VENDORED, DO NOT EDIT BY HAND. Source of truth:
+    spec repo: canon/py/canon.py  (contract: canon/SPEC.md)
+    source sha256: 53b9447a7f21dc05fabb3fb2505aadad2d494fc79f2ae60970ecfc8c6852bce0
+
+canon is not yet pip-installable, so it is vendored here verbatim to guarantee
+byte-for-byte fidelity with the spec reference impl. Fidelity is proven against
+the canon conformance vectors in tests/test_canon_vectors.py. To update, re-copy
+canon/py/canon.py from spec, refresh the sha256 above, and re-run that test.
+
+Requires: unicodedata2==16.0.0 (pinned Unicode 16.0 DB; see canon/SPEC.md S5).
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any, Iterable, Tuple
+
+# --------------------------------------------------------------------------- #
+# Unicode database pin (SPEC.md section 5) — load-bearing for cross-language byte-identity.
+#
+# NFC is defined against a Unicode version. Stdlib ``unicodedata`` is bound to whatever Unicode DB
+# the host CPython was built with (3.10 ships 13.0.0; newer builds differ), so it cannot guarantee
+# the SAME NFC as the TS port (Node ICU). We pin a maintained PyPI backport, ``unicodedata2``,
+# exactly to Node's Unicode version (16.0) and use it for ALL NFC. See canon/py/requirements.txt
+# for the exact pin; the assertion below is fail-closed so a wrong build can NEVER silently diverge.
+# --------------------------------------------------------------------------- #
+EXPECTED_UNICODE = "16.0"  # major.minor; matches Node's process.versions.unicode
+
+try:
+    import unicodedata2 as unicodedata  # pinned Unicode 16.0 DB (see requirements.txt)
+except ImportError as exc:  # pragma: no cover - environment misconfiguration
+    raise ImportError(
+        "canon requires the pinned 'unicodedata2' backport for a deterministic Unicode DB "
+        "(install canon/py/requirements.txt: unicodedata2==16.0.0). Stdlib 'unicodedata' is bound "
+        "to the host CPython build and would NOT match the TypeScript port byte-for-byte."
+    ) from exc
+
+
+def _unicode_major_minor(version: str) -> str:
+    """Reduce a Unicode version string (e.g. '16.0.0') to 'major.minor' (e.g. '16.0')."""
+    return ".".join(version.split(".")[:2])
+
+
+# Fail-closed version assertion (SPEC.md section 5). A mismatch here means the NFC DB in use is NOT
+# the pinned one, which is a determinism hole for a parity engine — so we refuse to load rather than
+# emit silently-divergent bytes. unicodedata2 reports e.g. '16.0.0'; Node reports '16.0'.
+_ACTUAL_UNICODE = _unicode_major_minor(unicodedata.unidata_version)
+if _ACTUAL_UNICODE != EXPECTED_UNICODE:
+    raise RuntimeError(
+        "canon Unicode DB mismatch: expected %s, got %s (from unicodedata2 %s). NFC determinism "
+        "across the Python and TypeScript ports is not guaranteed; refusing to load."
+        % (EXPECTED_UNICODE, _ACTUAL_UNICODE, unicodedata.unidata_version)
+    )
+
+# SPEC.md section 8 — the four digest profiles. ``locator`` is intentionally NOT a profile.
+PROFILES = ("semantic-content", "run", "artifact-byte", "certificate")
+_DOMAIN_PREFIX = "spec-canon:v1:"
+
+
+class CanonError(ValueError):
+    """Raised for any value outside the supported canonical domain (SPEC.md section 1/6)."""
+
+
+# --------------------------------------------------------------------------- #
+# String encoding (SPEC.md section 5)
+# --------------------------------------------------------------------------- #
+
+def _encode_string(s: str) -> str:
+    # NFC normalize first (also applied to keys before sorting, see _encode_object).
+    s = unicodedata.normalize("NFC", s)
+    out = ['"']
+    for ch in s:
+        cp = ord(ch)
+        if 0xD800 <= cp <= 0xDFFF:
+            # Unpaired surrogate: not valid scalar text. Python would raise on UTF-8 encode while
+            # JS emits U+FFFD -> silent byte-divergence. Reject in BOTH (SPEC.md section 5).
+            raise CanonError("unpaired surrogate U+%04X is not allowed in canonical content" % cp)
+        if ch == '"':
+            out.append('\\"')
+        elif ch == "\\":
+            out.append("\\\\")
+        elif cp <= 0x1F:
+            # Control chars: \uXXXX lowercase hex. No short escapes (no \n, \t, ...).
+            out.append("\\u%04x" % cp)
+        else:
+            # Everything else, incl. all non-ASCII and U+007F, is raw (ensure_ascii=False).
+            out.append(ch)
+    out.append('"')
+    return "".join(out)
+
+
+# --------------------------------------------------------------------------- #
+# Number encoding (SPEC.md section 6) — integers only.
+# --------------------------------------------------------------------------- #
+
+def _encode_int(value: int) -> str:
+    # bool is handled earlier; here value is a genuine int. str(int) is exactly the canonical
+    # shortest decimal form: optional '-', no leading zeros (except '0'), no '+', no exponent.
+    return str(value)
+
+
+# --------------------------------------------------------------------------- #
+# Object encoding (SPEC.md sections 3, 7) — keys NFC'd then sorted by code point.
+# --------------------------------------------------------------------------- #
+
+def _encode_object(obj: dict) -> str:
+    # Normalize keys to NFC before sorting; detect collisions.
+    normalized: dict[str, Any] = {}
+    for k, v in obj.items():
+        if not isinstance(k, str):
+            raise CanonError("object keys must be strings, got %r" % type(k).__name__)
+        nk = unicodedata.normalize("NFC", k)
+        if nk in normalized:
+            raise CanonError("key collision after NFC normalization: %r" % nk)
+        normalized[nk] = v
+    # Python str comparison is already by Unicode code point — correct for astral chars.
+    keys = sorted(normalized.keys())
+    parts = []
+    for k in keys:
+        parts.append(_encode_string(k) + ":" + _encode_value(normalized[k]))
+    return "{" + ",".join(parts) + "}"
+
+
+def _encode_array(arr: Iterable) -> str:
+    # Insertion order preserved ALWAYS (SPEC.md section 4). Never sort.
+    return "[" + ",".join(_encode_value(v) for v in arr) + "]"
+
+
+# --------------------------------------------------------------------------- #
+# Value dispatch — bool BEFORE int (SPEC.md section 6 boolean trap).
+# --------------------------------------------------------------------------- #
+
+def _encode_value(value: Any) -> str:
+    # Reject markers from the type-tagged decoder (SPEC.md section 2/6).
+    if isinstance(value, FloatMarker):
+        raise CanonError("floats are forbidden in canonical content; pre-represent as int or string")
+    if isinstance(value, NanMarker):
+        raise CanonError("NaN is forbidden in canonical content")
+    if isinstance(value, InfMarker):
+        raise CanonError("Infinity is forbidden in canonical content")
+    if value is None:
+        return "null"
+    if isinstance(value, bool):  # MUST precede int: isinstance(True, int) is True.
+        return "true" if value else "false"
+    if isinstance(value, int):
+        return _encode_int(value)
+    if isinstance(value, float):
+        raise CanonError("floats are forbidden in canonical content; pre-represent as int or string")
+    if isinstance(value, str):
+        return _encode_string(value)
+    if isinstance(value, dict):
+        return _encode_object(value)
+    if isinstance(value, (list, tuple)):
+        return _encode_array(value)
+    raise CanonError("unsupported type for canonical content: %s" % type(value).__name__)
+
+
+# --------------------------------------------------------------------------- #
+# Public API (SPEC.md sections 8, 9)
+# --------------------------------------------------------------------------- #
+
+def canonical_bytes(value: Any) -> bytes:
+    """Deterministic canonical UTF-8 bytes for a value in the supported domain."""
+    return _encode_value(value).encode("utf-8")
+
+
+def _strip_top_level_digest(value: Any) -> Any:
+    # SPEC.md section 8: exclude a top-level ``digest`` key only (nested is ordinary content).
+    if isinstance(value, dict) and "digest" in value:
+        return {k: v for k, v in value.items() if k != "digest"}
+    return value
+
+
+def digest(value: Any, profile: str) -> str:
+    """Lowercase-hex SHA-256 over domain_prefix(profile) || canonical_bytes(value)."""
+    if profile not in PROFILES:
+        raise CanonError("unknown digest profile: %r (allowed: %s)" % (profile, ", ".join(PROFILES)))
+    prefix = (_DOMAIN_PREFIX + profile + "\n").encode("ascii")
+    body = canonical_bytes(_strip_top_level_digest(value))
+    return hashlib.sha256(prefix + body).hexdigest()
+
+
+# --------------------------------------------------------------------------- #
+# Content/envelope split (SPEC.md section 10)
+# --------------------------------------------------------------------------- #
+
+def split_record(record: dict, content_keys: Iterable[str]) -> Tuple[dict, dict]:
+    """Split a record into (content, envelope). Only ``content`` is ever hashed."""
+    keyset = set(content_keys)
+    content = {k: v for k, v in record.items() if k in keyset}
+    envelope = {k: v for k, v in record.items() if k not in keyset}
+    return content, envelope
+
+
+# --------------------------------------------------------------------------- #
+# Type-tagged input decoder (SPEC.md section 2) — test harness, identical across languages.
+# --------------------------------------------------------------------------- #
+
+class FloatMarker:
+    """A value the encoder must reject (stands in for a float literal)."""
+
+
+class NanMarker:
+    pass
+
+
+class InfMarker:
+    def __init__(self, sign: int):
+        self.sign = sign
+
+
+def decode_input(node: Any) -> Any:
+    """Decode a type-tagged vector input tree into native values (or reject markers)."""
+    if isinstance(node, dict) and len(node) == 1:
+        (tag, payload), = node.items()
+        if tag == "$int":
+            return int(payload)  # decimal string -> arbitrary-precision int
+        if tag == "$float":
+            return FloatMarker()
+        if tag == "$nan":
+            return NanMarker()
+        if tag == "$inf":
+            return InfMarker(1 if payload >= 0 else -1)
+        if tag == "$str":
+            return payload
+        if tag == "$bool":
+            return bool(payload)
+        if tag == "$null":
+            return None
+        if tag == "$obj":
+            return {k: decode_input(v) for k, v in payload.items()}
+        if tag == "$arr":
+            return [decode_input(v) for v in payload]
+        # one-key dict that is not a tag: fall through to plain-dict handling
+    if isinstance(node, dict):
+        return {k: decode_input(v) for k, v in node.items()}
+    if isinstance(node, list):
+        return [decode_input(v) for v in node]
+    # bare scalars: str/bool/None pass through; a bare JSON number is treated as int if integral.
+    if isinstance(node, bool):
+        return node
+    if isinstance(node, int):
+        return node
+    if isinstance(node, float):
+        # Bare JSON float in a vector input -> a float marker (encoder rejects).
+        return FloatMarker()
+    return node

--- a/chunker/boundary/adapter.py
+++ b/chunker/boundary/adapter.py
@@ -128,7 +128,10 @@ def _boundary_kind(chunk: CodeChunk, metadata: dict[str, Any]) -> str:
 
 
 def _ensure_definition_id(chunk: CodeChunk, display_path: str) -> None:
-    if chunk.definition_id or not chunk.qualified_route:
+    # Always (re)compute from the canonical repo-relative display_path (BUG-3):
+    # the chunk may already carry a definition_id computed from a different
+    # (e.g. absolute) path, so do NOT early-return when it is already set.
+    if not chunk.qualified_route:
         return
     chunk.definition_id = compute_definition_id(
         display_path,
@@ -658,6 +661,7 @@ def _extract_file_cache_record(
                 detected_language,
                 extract_metadata=True,
                 include_retrieval_metadata=True,
+                identity_path=display_path,
             )
             _add_duration(timing_spans, "parse_ms", started_at)
         except Exception as exc:  # pragma: no cover - parser dependent
@@ -1011,7 +1015,9 @@ def extract_boundary_ir(
     serialization_failures = 0
 
     for file_path in files:
-        display_path = _display_path(file_path, root)
+        # BUG-4: normalize on the cold path too, so cold and incremental funnel
+        # every path through the same total normalization before any ID.
+        display_path = normalize_boundary_path(_display_path(file_path, root))
         detected_language = _detect_language(file_path, language)
         file_id = compute_file_id(display_path)
         file_diagnostics: list[str] = []
@@ -1025,6 +1031,7 @@ def extract_boundary_ir(
                     detected_language,
                     extract_metadata=True,
                     include_retrieval_metadata=True,
+                    identity_path=display_path,
                 )
                 _add_duration(timing_spans, "parse_ms", started_at)
             except Exception as exc:  # pragma: no cover - parser dependent

--- a/chunker/boundary/adapter.py
+++ b/chunker/boundary/adapter.py
@@ -90,11 +90,17 @@ def _stable_hash(*values: object) -> str:
 def _stable_value(value: Any) -> Any:
     if isinstance(value, dict):
         return {str(key): _stable_value(value[key]) for key in sorted(value)}
-    if isinstance(value, list | tuple | set):
-        values = [_stable_value(item) for item in value]
-        if all(isinstance(item, str) for item in values):
-            return sorted(dict.fromkeys(values))
-        return values
+    if isinstance(value, set):
+        # A set is genuinely order-insensitive AND has no source order to
+        # preserve, so it is the one collection we must order deterministically
+        # here. Stringify-sort to give canon a stable insertion order.
+        return sorted(_stable_value(item) for item in value)
+    if isinstance(value, list | tuple):
+        # canon S4: list/tuple order is preserved ALWAYS. NEVER content-sniff
+        # all-string lists into sorted(dict.fromkeys(...)) -- that destroyed
+        # order-significant fields (imports) and silently de-duplicated (BUG-1).
+        # Order-insensitive fields are sorted at construction / in the serializer.
+        return [_stable_value(item) for item in value]
     if isinstance(value, str | int | float | bool) or value is None:
         return value
     return str(value)

--- a/chunker/boundary/impact.py
+++ b/chunker/boundary/impact.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import posixpath
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -9,7 +10,26 @@ if TYPE_CHECKING:
 
 
 def normalize_boundary_path(path: str) -> str:
-    return path.replace("\\", "/")
+    """Total path normalization for Boundary IR identity + serialization (BUG-4).
+
+    Produces a single canonical repo-relative POSIX form so the same logical
+    path yields identical bytes regardless of OS separator or redundant
+    components -- cold and incremental extraction MUST funnel every path through
+    this one function before computing any ID or emitting any serialized path.
+
+    - POSIX-ify separators (Windows ``\\`` -> ``/``).
+    - Collapse ``.`` / ``..`` / redundant ``//`` via posix normpath.
+    - Empty / ``.`` -> ``""`` (the repo root display path), never ``"."``.
+
+    It is idempotent: normalize(normalize(p)) == normalize(p).
+    """
+    if not path:
+        return ""
+    posix = path.replace("\\", "/")
+    normalized = posixpath.normpath(posix)
+    if normalized == ".":
+        return ""
+    return normalized
 
 
 def detect_changed_paths(

--- a/chunker/boundary/serialization.py
+++ b/chunker/boundary/serialization.py
@@ -6,6 +6,16 @@ import json
 from copy import deepcopy
 from typing import Any
 
+from chunker.boundary import _canon
+
+# Fields excluded from the parity hash view (BUG-2 / canon S5 + locator).
+# These are volatile / provenance data (wall-clock, absolute paths, tool build,
+# timings) that MUST NOT enter hashed content -- otherwise the same logical code
+# hashes differently across machines, checkouts, and runs (false negatives).
+_PARITY_EXCLUDED_RUN_FIELDS = ("root", "created_at", "tool_version", "timings")
+# canon profile for Boundary-IR semantic content (the meaning-bearing structure).
+_PARITY_DIGEST_PROFILE = "semantic-content"
+
 
 def _location_start_line(record: dict[str, Any]) -> int:
     location = record.get("location")
@@ -104,3 +114,72 @@ def dumps_boundary_ir(ir: dict[str, Any], *, pretty: bool = False) -> str:
     if pretty:
         return json.dumps(canonical, indent=2, sort_keys=True) + "\n"
     return json.dumps(canonical, separators=(",", ":"), sort_keys=True) + "\n"
+
+
+def _strip_parity_volatile(canonical: dict[str, Any]) -> dict[str, Any]:
+    """Drop volatile/provenance fields that must not enter the parity hash (BUG-2).
+
+    Excludes the absolute ``source.path`` and the volatile ``run`` fields
+    (root, created_at, tool_version, timings). The fields stay in the full
+    emitted document (``dumps_boundary_ir``) for humans/debuggers -- only the
+    parity view drops them.
+    """
+    source = canonical.get("source")
+    if isinstance(source, dict):
+        source.pop("path", None)
+    run = canonical.get("run")
+    if isinstance(run, dict):
+        for field in _PARITY_EXCLUDED_RUN_FIELDS:
+            run.pop(field, None)
+    return canonical
+
+
+def _floats_to_strings(value: Any) -> Any:
+    """Recursively convert every float to its string repr (canon S6).
+
+    canon rejects ALL real numbers (cross-language float formatting is the single
+    largest source of byte-divergence), so any float in the IR -- semantic-edge
+    ``confidence``, ``run.options.semantic_min_confidence``, or any future field
+    -- is pre-represented as a string before canon sees it. The conversion is
+    generic (never a hand-enumerated field list) and deterministic: within a
+    field the type is stable, so this can never itself cause divergence.
+    """
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, float):
+        return repr(value)
+    if isinstance(value, dict):
+        return {key: _floats_to_strings(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_floats_to_strings(item) for item in value]
+    return value
+
+
+def canonicalize_for_parity(ir: dict[str, Any]) -> dict[str, Any]:
+    """Return the parity-hashable view of a Boundary IR (BUG-2).
+
+    Pipeline: canonicalize (apply the top-level + set-semantic sorts) -> strip
+    volatile fields (source.path, run.{root,created_at,tool_version,timings}) ->
+    pre-represent floats as strings. The result is a canon-compatible value: feed
+    it to ``canonicalize_for_parity_bytes`` / ``parity_digest`` for the actual
+    hash. This is the first-class API ``spec`` and other canon consumers call so
+    they never hand-strip volatile fields.
+    """
+    canonical = canonicalize_boundary_ir(ir)
+    canonical = _strip_parity_volatile(canonical)
+    return _floats_to_strings(canonical)
+
+
+def canonicalize_for_parity_bytes(ir: dict[str, Any]) -> bytes:
+    """canon canonical UTF-8 bytes of the parity view (cross-tool byte-identity).
+
+    Routes the parity view through the vendored canon serializer so the bytes are
+    byte-identical to every other canon consumer (spec, greenfield, codegraph-de)
+    -- not merely self-consistent JSON.
+    """
+    return _canon.canonical_bytes(canonicalize_for_parity(ir))
+
+
+def parity_digest(ir: dict[str, Any]) -> str:
+    """Lowercase-hex SHA-256 canon digest of the Boundary IR parity view (BUG-2)."""
+    return _canon.digest(canonicalize_for_parity(ir), _PARITY_DIGEST_PROFILE)

--- a/chunker/boundary/serialization.py
+++ b/chunker/boundary/serialization.py
@@ -29,10 +29,14 @@ def _canonicalize_value(value: Any) -> Any:
     if isinstance(value, dict):
         return {key: _canonicalize_value(value[key]) for key in sorted(value)}
     if isinstance(value, list):
-        canonical = [_canonicalize_value(item) for item in value]
-        if all(isinstance(item, str) for item in canonical):
-            return sorted(canonical)
-        return canonical
+        # canon rule (SPEC.md S4): array insertion order is preserved ALWAYS.
+        # The serializer never content-sniff-sorts lists -- reordering a list is a
+        # different logical value, so an order-significant field (params, imports,
+        # ...) MUST hash differently when reordered (BUG-1). The only authorized
+        # reorders are the explicit, field-keyed set-semantic sorts applied below
+        # in canonicalize_boundary_ir() (top-level files/nodes/edges/diagnostics,
+        # plus candidates / relationships / failure_buckets / file diagnostics).
+        return [_canonicalize_value(item) for item in value]
     return value
 
 
@@ -73,6 +77,24 @@ def canonicalize_boundary_ir(ir: dict[str, Any]) -> dict[str, Any]:
             item.get("id") or "",
         ),
     )
+
+    # Explicit, field-keyed set-semantic sorts (canon S4: only schema-declared
+    # order-insensitive lists may be ordered, and that ordering is the caller's,
+    # done before/at canonicalization -- NOT a content-sniff over arbitrary
+    # string lists). These are the only authorized array reorders besides the
+    # top-level files/nodes/edges/diagnostics sorts above. Every other list
+    # (params, imports, ...) preserves insertion order via _canonicalize_value.
+    for edge in canonical.get("edges", []):
+        if isinstance(edge, dict) and isinstance(edge.get("candidates"), list):
+            edge["candidates"] = sorted(edge["candidates"])
+    for node in canonical.get("nodes", []):
+        if isinstance(node, dict) and isinstance(node.get("relationships"), list):
+            node["relationships"] = sorted(node["relationships"])
+    for file_record in canonical.get("files", []):
+        if isinstance(file_record, dict) and isinstance(
+            file_record.get("diagnostics"), list
+        ):
+            file_record["diagnostics"] = sorted(file_record["diagnostics"])
     return canonical
 
 

--- a/chunker/core.py
+++ b/chunker/core.py
@@ -140,8 +140,16 @@ def _format_signature_text(signature: object) -> str | None:
     return signature_text
 
 
-def _normalize_text_list(value: object) -> list[str]:
-    """Normalize metadata values into a stable string list."""
+def _normalize_text_list(value: object, *, sort: bool = True) -> list[str]:
+    """Normalize metadata values into a stable string list.
+
+    ``sort=True`` (default) returns a sorted, de-duplicated list for genuinely
+    order-insensitive (set-semantic) fields such as exports/dependencies.
+    ``sort=False`` preserves source order (still de-duplicating, order-stably)
+    for order-significant fields such as imports -- canon S4 forbids reordering
+    an order-significant list, and BUG-1b established imports as order-significant
+    (side-effecting import order can matter). Never sort to mask nondeterminism.
+    """
     if value is None:
         return []
     if isinstance(value, str):
@@ -150,9 +158,8 @@ def _normalize_text_list(value: object) -> list[str]:
         values = [str(item) for item in value if item is not None]
     else:
         values = [str(value)]
-    return sorted(
-        dict.fromkeys(item.strip() for item in values if item and item.strip())
-    )
+    deduped = dict.fromkeys(item.strip() for item in values if item and item.strip())
+    return sorted(deduped) if sort else list(deduped)
 
 
 def _build_semantic_text(
@@ -178,7 +185,11 @@ def _build_semantic_text(
             lines.append(f"{label}: {value}")
 
     for key in ("imports", "exports", "dependencies"):
-        values = _normalize_text_list(retrieval_metadata.get(key))
+        # imports are order-significant (preserve source order); exports and
+        # dependencies are set-semantic (sort). See _normalize_text_list / BUG-1b.
+        values = _normalize_text_list(
+            retrieval_metadata.get(key), sort=(key != "imports")
+        )
         if values:
             lines.append(f"{key}: {', '.join(values)}")
 
@@ -235,7 +246,8 @@ def _build_retrieval_metadata(chunk: CodeChunk) -> dict[str, object]:
         "parent_symbol": parent_symbol,
         "semantic_path": semantic_path,
         "signature_text": _format_signature_text(signature),
-        "imports": _normalize_text_list(metadata.get("imports")),
+        # imports order-significant -> preserve; exports/dependencies set-semantic.
+        "imports": _normalize_text_list(metadata.get("imports"), sort=False),
         "exports": _normalize_text_list(metadata.get("exports")),
         "dependencies": _normalize_text_list(
             metadata.get("dependencies", chunk.dependencies)

--- a/chunker/core.py
+++ b/chunker/core.py
@@ -1020,20 +1020,28 @@ def chunk_file(
     language: str,
     extract_metadata: bool = True,
     include_retrieval_metadata: bool = False,
+    identity_path: str | None = None,
 ) -> list[CodeChunk]:
     """Parse the file and return a list of `CodeChunk`.
 
     Args:
-        path: Path to the file to chunk
+        path: Path to the file to chunk (used to READ the file).
         language: Programming language
         extract_metadata: Whether to extract metadata (default: True)
         include_retrieval_metadata: Whether to add retrieval-oriented metadata
+        identity_path: Path baked into all chunk IDs (node_id/file_id/symbol_id/
+            chunk_id), parent links, and semantic_text. Defaults to ``str(path)``
+            to preserve legacy behavior; the Boundary adapter passes the
+            normalized repo-relative path so IDs are checkout-root independent
+            (BUG-3). The read path and the identity path are intentionally
+            decoupled.
 
     Returns:
         List of CodeChunk objects with optional metadata
     """
     # Read file contents with robust decoding
     p = Path(path)
+    identity = identity_path if identity_path is not None else str(path)
     try:
         src = p.read_text(encoding="utf-8")
     except UnicodeDecodeError:
@@ -1059,8 +1067,9 @@ def chunk_file(
             )
         all_chunks: list[CodeChunk] = []
         for code, start, end in snippets:
-            # Derive pseudo file name for chunk id stability
-            pseudo_path = f"{p}:{start}-{end}"
+            # Derive pseudo file name for chunk id stability (keyed on the
+            # identity path so IDs are checkout-root independent).
+            pseudo_path = f"{identity}:{start}-{end}"
             all_chunks.extend(
                 chunk_text(
                     code,
@@ -1075,7 +1084,7 @@ def chunk_file(
     return chunk_text(
         src,
         language,
-        str(path),
+        identity,
         extract_metadata=extract_metadata,
         include_retrieval_metadata=include_retrieval_metadata,
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,6 +168,11 @@ exclude_lines = [
 line-length = 88
 target-version = ['py311', 'py312', 'py313']
 include = '\.pyi?$'
+# force-exclude applies even when a path is passed explicitly on the CLI. The
+# vendored canon serializer (chunker/boundary/_canon.py) is copied verbatim from
+# the spec reference impl (digest pinned in its header) and MUST NOT be
+# reformatted, or it would diverge from the source of truth.
+force-exclude = 'chunker/boundary/_canon\.py'
 extend-exclude = '''
 /(
   # directories

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,10 @@ dependencies = [
     "networkx>=3.0",
     "leidenalg>=0.10.0",
     "igraph>=0.11.0",  # Required by leidenalg
+    # Pinned Unicode 16.0 DB for the vendored canon v1 serializer (chunker/boundary/_canon.py).
+    # canon's NFC must match the spec reference byte-for-byte; stdlib unicodedata is bound to the
+    # host CPython build, so canon pins this backport. See canon/SPEC.md S5.
+    "unicodedata2==16.0.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/fixtures/boundary_ir/golden/go.json
+++ b/tests/fixtures/boundary_ir/golden/go.json
@@ -386,9 +386,9 @@
         "exports": [],
         "imports": [],
         "parent_symbol": null,
-        "semantic_text": "language: go\nfile: tests/fixtures/boundary_ir/repos/go/beta.go\nkind: function\nsymbol: helper\nqualified name: helper\nsemantic path: tests/fixtures/boundary_ir/repos/go/beta.go::helper\nsignature text: helper(value string)\ndependencies: value\ncontent:\nfunc helper(value string) string {\n\treturn value\n}"
+        "semantic_text": "language: go\nfile: beta.go\nkind: function\nsymbol: helper\nqualified name: helper\nsemantic path: beta.go::helper\nsignature text: helper(value string)\ndependencies: value\ncontent:\nfunc helper(value string) string {\n\treturn value\n}"
       },
-      "node_id": "86b4f10e6fb113d9f88b7a2ceee55b8871f2004d",
+      "node_id": "87ce9d788f8360374946c0e5e84daab4eb5778f7",
       "parent": null,
       "path": "beta.go",
       "provenance": {
@@ -399,7 +399,7 @@
       "relationships": [
         "edge:a3898180bbd8cd3a"
       ],
-      "semantic_path": "tests/fixtures/boundary_ir/repos/go/beta.go::helper",
+      "semantic_path": "beta.go::helper",
       "signature": "helper(value string)",
       "span": {
         "byte_end": 71,
@@ -408,7 +408,7 @@
         "start_line": 3
       },
       "symbol": "helper",
-      "symbol_id": "ba3d4f1ad2c7f125fc128243362b2a23158c9a59"
+      "symbol_id": "8d96dda3611a4ad21f61d7c78c66378eb5c9f856"
     },
     {
       "definition_id": "0b7a1617a7099f1a1cc62654bacbf737d7a1a45f",
@@ -427,9 +427,9 @@
         ],
         "imports": [],
         "parent_symbol": null,
-        "semantic_text": "language: go\nfile: tests/fixtures/boundary_ir/repos/go/format.go\nkind: type\nsemantic path: tests/fixtures/boundary_ir/repos/go/format.go\nexports: Widget\ncontent:\ntype Widget struct {\n\tName string\n}"
+        "semantic_text": "language: go\nfile: format.go\nkind: type\nsemantic path: format.go\nexports: Widget\ncontent:\ntype Widget struct {\n\tName string\n}"
       },
-      "node_id": "2f7c4669cd3ab8f52476a70a5920ba6633489e27",
+      "node_id": "56ff4bac387a01697da4772475e0b3080d98f819",
       "parent": null,
       "path": "format.go",
       "provenance": {
@@ -438,7 +438,7 @@
       },
       "qualified_name": null,
       "relationships": [],
-      "semantic_path": "tests/fixtures/boundary_ir/repos/go/format.go",
+      "semantic_path": "format.go",
       "signature": null,
       "span": {
         "byte_end": 74,
@@ -469,9 +469,9 @@
         ],
         "imports": [],
         "parent_symbol": null,
-        "semantic_text": "language: go\nfile: tests/fixtures/boundary_ir/repos/go/format.go\nkind: function\nsymbol: Format\nqualified name: Format\nsemantic path: tests/fixtures/boundary_ir/repos/go/format.go::Format\nsignature text: Format(value string)\nexports: Format\ndependencies: strings, value\ncontent:\nfunc Format(value string) string {\n\treturn strings.TrimSpace(value)\n}"
+        "semantic_text": "language: go\nfile: format.go\nkind: function\nsymbol: Format\nqualified name: Format\nsemantic path: format.go::Format\nsignature text: Format(value string)\nexports: Format\ndependencies: strings, value\ncontent:\nfunc Format(value string) string {\n\treturn strings.TrimSpace(value)\n}"
       },
-      "node_id": "b1633e176caca94449f5f5bab21c99a52de6e529",
+      "node_id": "fa8191478fe3963d11925259c5cec76ef9a22bd3",
       "parent": null,
       "path": "format.go",
       "provenance": {
@@ -484,7 +484,7 @@
         "edge:d3faacbf277b431b",
         "edge:e1b76270e5745f55"
       ],
-      "semantic_path": "tests/fixtures/boundary_ir/repos/go/format.go::Format",
+      "semantic_path": "format.go::Format",
       "signature": "Format(value string)",
       "span": {
         "byte_end": 145,
@@ -493,7 +493,7 @@
         "start_line": 9
       },
       "symbol": "Format",
-      "symbol_id": "3c35c81458b9b57587be1b0ea6508bf052a9cbf1"
+      "symbol_id": "b3b5b0edc4ed4f5376065baf0d275b5232ca79f2"
     },
     {
       "definition_id": "6c6d2514190884959b91c1b42fbf90c94e1ef83a",
@@ -512,9 +512,9 @@
         "exports": [],
         "imports": [],
         "parent_symbol": null,
-        "semantic_text": "language: go\nfile: tests/fixtures/boundary_ir/repos/go/alpha.go\nkind: function\nsymbol: helper\nqualified name: helper\nsemantic path: tests/fixtures/boundary_ir/repos/go/alpha.go::helper\nsignature text: helper(value string)\ndependencies: value\ncontent:\nfunc helper(value string) string {\n\treturn value\n}"
+        "semantic_text": "language: go\nfile: alpha.go\nkind: function\nsymbol: helper\nqualified name: helper\nsemantic path: alpha.go::helper\nsignature text: helper(value string)\ndependencies: value\ncontent:\nfunc helper(value string) string {\n\treturn value\n}"
       },
-      "node_id": "7b366f13a539d5faa3f4ef3cf16bb65b0f381eb7",
+      "node_id": "caf07603c95ce42e118ea9ac760515cf5abb49a6",
       "parent": null,
       "path": "alpha.go",
       "provenance": {
@@ -525,7 +525,7 @@
       "relationships": [
         "edge:e9303e27e5900f9e"
       ],
-      "semantic_path": "tests/fixtures/boundary_ir/repos/go/alpha.go::helper",
+      "semantic_path": "alpha.go::helper",
       "signature": "helper(value string)",
       "span": {
         "byte_end": 71,
@@ -534,7 +534,7 @@
         "start_line": 3
       },
       "symbol": "helper",
-      "symbol_id": "c1e030aced7ef6492cb6c143434d4e24758dbb00"
+      "symbol_id": "c40941f2d70c916d30f2fab769c7a9c7a43b772c"
     },
     {
       "definition_id": "c929955174ede1c6857e22b2f555fe70f66912d6",
@@ -558,9 +558,9 @@
         ],
         "imports": [],
         "parent_symbol": null,
-        "semantic_text": "language: go\nfile: tests/fixtures/boundary_ir/repos/go/service.go\nkind: function\nsymbol: Render\nqualified name: Render\nsemantic path: tests/fixtures/boundary_ir/repos/go/service.go::Render\nsignature text: Render(value string)\nexports: Render\ndependencies: Format, Ghost, helper, value\ncontent:\nfunc Render(value string) string {\n\tcleaned := Format(value)\n\tduplicate := helper(cleaned)\n\treturn Ghost(duplicate)\n}"
+        "semantic_text": "language: go\nfile: service.go\nkind: function\nsymbol: Render\nqualified name: Render\nsemantic path: service.go::Render\nsignature text: Render(value string)\nexports: Render\ndependencies: Format, Ghost, helper, value\ncontent:\nfunc Render(value string) string {\n\tcleaned := Format(value)\n\tduplicate := helper(cleaned)\n\treturn Ghost(duplicate)\n}"
       },
-      "node_id": "0a30f2aa3bedb4fc7924e78f2431a7f89815c841",
+      "node_id": "4a0e1f0506d85bd069d04b3fb57508b756962599",
       "parent": null,
       "path": "service.go",
       "provenance": {
@@ -577,7 +577,7 @@
         "edge:f0a02391bb742db0",
         "edge:f1554145262a03fd"
       ],
-      "semantic_path": "tests/fixtures/boundary_ir/repos/go/service.go::Render",
+      "semantic_path": "service.go::Render",
       "signature": "Render(value string)",
       "span": {
         "byte_end": 138,
@@ -586,7 +586,7 @@
         "start_line": 3
       },
       "symbol": "Render",
-      "symbol_id": "f0003f3d49e7f21488e24099bcfeda5515ab867b"
+      "symbol_id": "4648882eee0f9320649bcd19f74a49c7b8b12ac2"
     },
     {
       "definition_id": "f24a08c0aec67c2ddce935db79b4d7c13bb64902",
@@ -605,10 +605,10 @@
         ],
         "imports": [],
         "parent_symbol": null,
-        "semantic_text": "language: go\nfile: tests/fixtures/boundary_ir/repos/go/format.go\nkind: type\nsymbol: Widget\nqualified name: Widget\nsemantic path: tests/fixtures/boundary_ir/repos/go/format.go::Widget\nexports: Widget\ncontent:\nWidget struct {\n\tName string\n}"
+        "semantic_text": "language: go\nfile: format.go\nkind: type\nsymbol: Widget\nqualified name: Widget\nsemantic path: format.go::Widget\nexports: Widget\ncontent:\nWidget struct {\n\tName string\n}"
       },
-      "node_id": "d6f5b5c6f77f17f2758ef4d9992fb42deb94f6cb",
-      "parent": "2f7c4669cd3ab8f52476a70a5920ba6633489e27",
+      "node_id": "9828c43e61ce4d7bafbc712f1d7fbd86ec7f1807",
+      "parent": "56ff4bac387a01697da4772475e0b3080d98f819",
       "path": "format.go",
       "provenance": {
         "extractor": "chunk_file",
@@ -616,7 +616,7 @@
       },
       "qualified_name": "Widget",
       "relationships": [],
-      "semantic_path": "tests/fixtures/boundary_ir/repos/go/format.go::Widget",
+      "semantic_path": "format.go::Widget",
       "signature": null,
       "span": {
         "byte_end": 74,
@@ -625,7 +625,7 @@
         "start_line": 5
       },
       "symbol": "Widget",
-      "symbol_id": "d84fea4ea05b78aa7c7630451525acfe63bf1b12"
+      "symbol_id": "13a3bdadafdd10003254406446b3d34b8cee5e07"
     }
   ],
   "run": {

--- a/tests/fixtures/boundary_ir/golden/javascript.json
+++ b/tests/fixtures/boundary_ir/golden/javascript.json
@@ -420,10 +420,10 @@
         "exports": [],
         "imports": [],
         "parent_symbol": "run",
-        "semantic_text": "language: javascript\nfile: tests/fixtures/boundary_ir/repos/javascript/service.js\nkind: variable_declarator\nsymbol: cleaned\nqualified name: run.cleaned\nparent symbol: run\nsemantic path: tests/fixtures/boundary_ir/repos/javascript/service.js::run.cleaned\ndependencies: formatName, value\ncontent:\ncleaned = formatName(value)"
+        "semantic_text": "language: javascript\nfile: service.js\nkind: variable_declarator\nsymbol: cleaned\nqualified name: run.cleaned\nparent symbol: run\nsemantic path: service.js::run.cleaned\ndependencies: formatName, value\ncontent:\ncleaned = formatName(value)"
       },
-      "node_id": "89c1a7f001367236185d07da4ae9f78b87381c21",
-      "parent": "9ee6f8c45786007268b21e77fa85d637bc93a56e",
+      "node_id": "4485b79b57db3ea482a2e6ae7d880c9998218682",
+      "parent": "dcdb38178db8a5cb54fbcad7b71b42e47fff79f8",
       "path": "service.js",
       "provenance": {
         "extractor": "chunk_file",
@@ -431,7 +431,7 @@
       },
       "qualified_name": "run.cleaned",
       "relationships": [],
-      "semantic_path": "tests/fixtures/boundary_ir/repos/javascript/service.js::run.cleaned",
+      "semantic_path": "service.js::run.cleaned",
       "signature": null,
       "span": {
         "byte_end": 186,
@@ -440,7 +440,7 @@
         "start_line": 10
       },
       "symbol": "cleaned",
-      "symbol_id": "b4011a7d4c9224600b871f0be96fb43493f1a711"
+      "symbol_id": "24d06201dc19a8b9e5e8bbd5c97f5f26acc3cbdf"
     },
     {
       "definition_id": "3259abf65ed857b2e9f06afa3170021f6c71b61c",
@@ -459,10 +459,10 @@
         ],
         "imports": [],
         "parent_symbol": null,
-        "semantic_text": "language: javascript\nfile: tests/fixtures/boundary_ir/repos/javascript/format.js\nkind: function\nsymbol: formatName\nqualified name: formatName\nsemantic path: tests/fixtures/boundary_ir/repos/javascript/format.js::formatName\nsignature text: formatName(value)\nexports: formatName\ncontent:\nfunction formatName(value) {\n  return value.trim();\n}"
+        "semantic_text": "language: javascript\nfile: format.js\nkind: function\nsymbol: formatName\nqualified name: formatName\nsemantic path: format.js::formatName\nsignature text: formatName(value)\nexports: formatName\ncontent:\nfunction formatName(value) {\n  return value.trim();\n}"
       },
-      "node_id": "c1745a37fac207c65756f897908f907332fb703e",
-      "parent": "4966d913577467fd790d4f5ca66bf8f949d0bdeb",
+      "node_id": "6b574be4b0a45dabf262574ce93e166d861e7a81",
+      "parent": "ef1570ad367c15ad79d083a2b5b97ce2b52a1e89",
       "path": "format.js",
       "provenance": {
         "extractor": "chunk_file",
@@ -472,7 +472,7 @@
       "relationships": [
         "edge:41c0fd3741b27592"
       ],
-      "semantic_path": "tests/fixtures/boundary_ir/repos/javascript/format.js::formatName",
+      "semantic_path": "format.js::formatName",
       "signature": "formatName(value)",
       "span": {
         "byte_end": 60,
@@ -481,7 +481,7 @@
         "start_line": 1
       },
       "symbol": "formatName",
-      "symbol_id": "9fcf55e4fbdc5a233803ea857385f6aaa1e0a057"
+      "symbol_id": "1a4caa5ef5c429536d6f9bbaf8e9ad9312c2d7ba"
     },
     {
       "definition_id": "3e9775a7d997a10d69f3cb10e69283319d0d3d5a",
@@ -500,9 +500,9 @@
         ],
         "imports": [],
         "parent_symbol": null,
-        "semantic_text": "language: javascript\nfile: tests/fixtures/boundary_ir/repos/javascript/beta.js\nkind: export_statement\nsemantic path: tests/fixtures/boundary_ir/repos/javascript/beta.js\nexports: helper\ncontent:\nexport function helper(value) {\n  return value.toUpperCase();\n}"
+        "semantic_text": "language: javascript\nfile: beta.js\nkind: export_statement\nsemantic path: beta.js\nexports: helper\ncontent:\nexport function helper(value) {\n  return value.toUpperCase();\n}"
       },
-      "node_id": "863c01c32c503600b6f80ccd18df8fd4702f10a5",
+      "node_id": "f7c5c85a3998e87da870ec9f4731480bc8f9ef0c",
       "parent": null,
       "path": "beta.js",
       "provenance": {
@@ -511,7 +511,7 @@
       },
       "qualified_name": null,
       "relationships": [],
-      "semantic_path": "tests/fixtures/boundary_ir/repos/javascript/beta.js",
+      "semantic_path": "beta.js",
       "signature": null,
       "span": {
         "byte_end": 63,
@@ -541,10 +541,10 @@
         ],
         "imports": [],
         "parent_symbol": "Renderer",
-        "semantic_text": "language: javascript\nfile: tests/fixtures/boundary_ir/repos/javascript/service.js\nkind: method\nsymbol: render\nqualified name: Renderer.render\nparent symbol: Renderer\nsemantic path: tests/fixtures/boundary_ir/repos/javascript/service.js::Renderer.render\nsignature text: render(value)\nexports: render\ndependencies: formatName\ncontent:\nrender(value) {\n    return formatName(value);\n  }"
+        "semantic_text": "language: javascript\nfile: service.js\nkind: method\nsymbol: render\nqualified name: Renderer.render\nparent symbol: Renderer\nsemantic path: service.js::Renderer.render\nsignature text: render(value)\nexports: render\ndependencies: formatName\ncontent:\nrender(value) {\n    return formatName(value);\n  }"
       },
-      "node_id": "935bf5a4a7b943a66b334c9b7bc47c1ca01f1896",
-      "parent": "37a91f3c36ef8c17b887ff4c36bbaaa0cdfa25c3",
+      "node_id": "93b8bc67d830640e1b1ae72e02a77455790cef8a",
+      "parent": "241723aa1af9d42ff01c7e69b9c9155d6a9366be",
       "path": "service.js",
       "provenance": {
         "extractor": "chunk_file",
@@ -555,7 +555,7 @@
         "edge:44451a6bd5fea4ae",
         "edge:dc5813871593964f"
       ],
-      "semantic_path": "tests/fixtures/boundary_ir/repos/javascript/service.js::Renderer.render",
+      "semantic_path": "service.js::Renderer.render",
       "signature": "render(value)",
       "span": {
         "byte_end": 118,
@@ -564,7 +564,7 @@
         "start_line": 4
       },
       "symbol": "render",
-      "symbol_id": "0c5d349a2188e9be1ca8a2495d95bc1bbe2e31d5"
+      "symbol_id": "ff3e034c1b13598c950adfacaf678a8ab1cd6852"
     },
     {
       "definition_id": "4efcc76af1457279a57d4a7d8c45e394821130e0",
@@ -583,10 +583,10 @@
         ],
         "imports": [],
         "parent_symbol": null,
-        "semantic_text": "language: javascript\nfile: tests/fixtures/boundary_ir/repos/javascript/alpha.js\nkind: function\nsymbol: helper\nqualified name: helper\nsemantic path: tests/fixtures/boundary_ir/repos/javascript/alpha.js::helper\nsignature text: helper(value)\nexports: helper\ncontent:\nfunction helper(value) {\n  return value.toLowerCase();\n}"
+        "semantic_text": "language: javascript\nfile: alpha.js\nkind: function\nsymbol: helper\nqualified name: helper\nsemantic path: alpha.js::helper\nsignature text: helper(value)\nexports: helper\ncontent:\nfunction helper(value) {\n  return value.toLowerCase();\n}"
       },
-      "node_id": "63be99499c85dbb27a1fd7ecf30158f3b801e1dc",
-      "parent": "6c0a2663718c4bd95ff534fd9639fb5713f14bff",
+      "node_id": "309c20375ea6c3b4345028b9bf13f7ad73084ab6",
+      "parent": "08f8cd26961c161a8f6e3ab65d5574790f5e3e75",
       "path": "alpha.js",
       "provenance": {
         "extractor": "chunk_file",
@@ -596,7 +596,7 @@
       "relationships": [
         "edge:c6a2c92931d5716b"
       ],
-      "semantic_path": "tests/fixtures/boundary_ir/repos/javascript/alpha.js::helper",
+      "semantic_path": "alpha.js::helper",
       "signature": "helper(value)",
       "span": {
         "byte_end": 63,
@@ -605,7 +605,7 @@
         "start_line": 1
       },
       "symbol": "helper",
-      "symbol_id": "c9f58681d4556e51b3b6bc985cb7e8c3d43cdcb4"
+      "symbol_id": "a9ef56286cc6fe2d21ae93aa94caf7cb240ba96b"
     },
     {
       "definition_id": "57004cdc6c66281504819eb98ea5b1efa62e144a",
@@ -628,10 +628,10 @@
         ],
         "imports": [],
         "parent_symbol": null,
-        "semantic_text": "language: javascript\nfile: tests/fixtures/boundary_ir/repos/javascript/service.js\nkind: function\nsymbol: run\nqualified name: run\nsemantic path: tests/fixtures/boundary_ir/repos/javascript/service.js::run\nsignature text: run(value)\nexports: run\ndependencies: formatName, helper, missingCall\ncontent:\nfunction run(value) {\n  const cleaned = formatName(value);\n  const duplicate = helper(cleaned);\n  return missingCall(duplicate);\n}"
+        "semantic_text": "language: javascript\nfile: service.js\nkind: function\nsymbol: run\nqualified name: run\nsemantic path: service.js::run\nsignature text: run(value)\nexports: run\ndependencies: formatName, helper, missingCall\ncontent:\nfunction run(value) {\n  const cleaned = formatName(value);\n  const duplicate = helper(cleaned);\n  return missingCall(duplicate);\n}"
       },
-      "node_id": "9ee6f8c45786007268b21e77fa85d637bc93a56e",
-      "parent": "fee72e89bc1f9d0d35028260430bcb8d1fc576cf",
+      "node_id": "dcdb38178db8a5cb54fbcad7b71b42e47fff79f8",
+      "parent": "499684ec51372ed18680e9154ae0de14595dadb4",
       "path": "service.js",
       "provenance": {
         "extractor": "chunk_file",
@@ -646,7 +646,7 @@
         "edge:d0600e0b69c5ec35",
         "edge:e07f41af44ceea6f"
       ],
-      "semantic_path": "tests/fixtures/boundary_ir/repos/javascript/service.js::run",
+      "semantic_path": "service.js::run",
       "signature": "run(value)",
       "span": {
         "byte_end": 259,
@@ -655,7 +655,7 @@
         "start_line": 9
       },
       "symbol": "run",
-      "symbol_id": "73a66d46936e2bc6dac8afa39846184e9a027152"
+      "symbol_id": "ed5b413865de011c4fc049540dc1eb9d7550548d"
     },
     {
       "definition_id": "a31f7d0d98b9d472efd500c92d4b675b1b20348c",
@@ -676,10 +676,10 @@
         ],
         "imports": [],
         "parent_symbol": null,
-        "semantic_text": "language: javascript\nfile: tests/fixtures/boundary_ir/repos/javascript/service.js\nkind: class\nsymbol: Renderer\nqualified name: Renderer\nsemantic path: tests/fixtures/boundary_ir/repos/javascript/service.js::Renderer\nexports: Renderer\ndependencies: formatName\ncontent:\nclass Renderer {\n  render(value) {\n    return formatName(value);\n  }\n}"
+        "semantic_text": "language: javascript\nfile: service.js\nkind: class\nsymbol: Renderer\nqualified name: Renderer\nsemantic path: service.js::Renderer\nexports: Renderer\ndependencies: formatName\ncontent:\nclass Renderer {\n  render(value) {\n    return formatName(value);\n  }\n}"
       },
-      "node_id": "37a91f3c36ef8c17b887ff4c36bbaaa0cdfa25c3",
-      "parent": "fff010c9be63ef49e896b3b2681ed1c4fd9b8fb1",
+      "node_id": "241723aa1af9d42ff01c7e69b9c9155d6a9366be",
+      "parent": "547bae8a0fcd8921e21f8a4ba45f7983b23ced30",
       "path": "service.js",
       "provenance": {
         "extractor": "chunk_file",
@@ -690,7 +690,7 @@
         "edge:bb19cb90d4a5429e",
         "edge:fa4ead388c6eca68"
       ],
-      "semantic_path": "tests/fixtures/boundary_ir/repos/javascript/service.js::Renderer",
+      "semantic_path": "service.js::Renderer",
       "signature": null,
       "span": {
         "byte_end": 120,
@@ -699,7 +699,7 @@
         "start_line": 3
       },
       "symbol": "Renderer",
-      "symbol_id": "84482e54d49bcaa5564c02ea78eb9375c311d2ea"
+      "symbol_id": "69bc24249b5516b75a05ff3ce7be3b04591383eb"
     },
     {
       "definition_id": "a7df3e6ec08e44dbdeaec19fbd47909ba41201aa",
@@ -721,9 +721,9 @@
           "{ formatName }"
         ],
         "parent_symbol": null,
-        "semantic_text": "language: javascript\nfile: tests/fixtures/boundary_ir/repos/javascript/service.js\nkind: import_statement\nsemantic path: tests/fixtures/boundary_ir/repos/javascript/service.js\nimports: import { formatName } from './format.js';, { formatName }\ndependencies: formatName\ncontent:\nimport { formatName } from './format.js';"
+        "semantic_text": "language: javascript\nfile: service.js\nkind: import_statement\nsemantic path: service.js\nimports: import { formatName } from './format.js';, { formatName }\ndependencies: formatName\ncontent:\nimport { formatName } from './format.js';"
       },
-      "node_id": "1dd38589405d84d51db1d44d7afe90ed5da9edc8",
+      "node_id": "4f31f95cca13c9d50d2d588ccb9ae518304660d2",
       "parent": null,
       "path": "service.js",
       "provenance": {
@@ -732,7 +732,7 @@
       },
       "qualified_name": null,
       "relationships": [],
-      "semantic_path": "tests/fixtures/boundary_ir/repos/javascript/service.js",
+      "semantic_path": "service.js",
       "signature": null,
       "span": {
         "byte_end": 41,
@@ -760,9 +760,9 @@
         ],
         "imports": [],
         "parent_symbol": null,
-        "semantic_text": "language: javascript\nfile: tests/fixtures/boundary_ir/repos/javascript/alpha.js\nkind: export_statement\nsemantic path: tests/fixtures/boundary_ir/repos/javascript/alpha.js\nexports: helper\ncontent:\nexport function helper(value) {\n  return value.toLowerCase();\n}"
+        "semantic_text": "language: javascript\nfile: alpha.js\nkind: export_statement\nsemantic path: alpha.js\nexports: helper\ncontent:\nexport function helper(value) {\n  return value.toLowerCase();\n}"
       },
-      "node_id": "6c0a2663718c4bd95ff534fd9639fb5713f14bff",
+      "node_id": "08f8cd26961c161a8f6e3ab65d5574790f5e3e75",
       "parent": null,
       "path": "alpha.js",
       "provenance": {
@@ -771,7 +771,7 @@
       },
       "qualified_name": null,
       "relationships": [],
-      "semantic_path": "tests/fixtures/boundary_ir/repos/javascript/alpha.js",
+      "semantic_path": "alpha.js",
       "signature": null,
       "span": {
         "byte_end": 63,
@@ -799,10 +799,10 @@
         ],
         "imports": [],
         "parent_symbol": null,
-        "semantic_text": "language: javascript\nfile: tests/fixtures/boundary_ir/repos/javascript/beta.js\nkind: function\nsymbol: helper\nqualified name: helper\nsemantic path: tests/fixtures/boundary_ir/repos/javascript/beta.js::helper\nsignature text: helper(value)\nexports: helper\ncontent:\nfunction helper(value) {\n  return value.toUpperCase();\n}"
+        "semantic_text": "language: javascript\nfile: beta.js\nkind: function\nsymbol: helper\nqualified name: helper\nsemantic path: beta.js::helper\nsignature text: helper(value)\nexports: helper\ncontent:\nfunction helper(value) {\n  return value.toUpperCase();\n}"
       },
-      "node_id": "2ede36cc9f71fc09bda333fd937e0ed1f5716e7f",
-      "parent": "863c01c32c503600b6f80ccd18df8fd4702f10a5",
+      "node_id": "adf72758af0d5ce86b88bcd24a885baa0c9aded5",
+      "parent": "f7c5c85a3998e87da870ec9f4731480bc8f9ef0c",
       "path": "beta.js",
       "provenance": {
         "extractor": "chunk_file",
@@ -812,7 +812,7 @@
       "relationships": [
         "edge:557e4fe789d374ec"
       ],
-      "semantic_path": "tests/fixtures/boundary_ir/repos/javascript/beta.js::helper",
+      "semantic_path": "beta.js::helper",
       "signature": "helper(value)",
       "span": {
         "byte_end": 63,
@@ -821,7 +821,7 @@
         "start_line": 1
       },
       "symbol": "helper",
-      "symbol_id": "91f7b8db0fc975eb755fd5a7555007a52b85249d"
+      "symbol_id": "38fdd0915154d33f784396d69d3ef26aa2f538e9"
     },
     {
       "definition_id": "bbaaaa1f1d7e4cc2673c787ee4da39a3f95beb1e",
@@ -840,9 +840,9 @@
         ],
         "imports": [],
         "parent_symbol": null,
-        "semantic_text": "language: javascript\nfile: tests/fixtures/boundary_ir/repos/javascript/format.js\nkind: export_statement\nsemantic path: tests/fixtures/boundary_ir/repos/javascript/format.js\nexports: formatName\ncontent:\nexport function formatName(value) {\n  return value.trim();\n}"
+        "semantic_text": "language: javascript\nfile: format.js\nkind: export_statement\nsemantic path: format.js\nexports: formatName\ncontent:\nexport function formatName(value) {\n  return value.trim();\n}"
       },
-      "node_id": "4966d913577467fd790d4f5ca66bf8f949d0bdeb",
+      "node_id": "ef1570ad367c15ad79d083a2b5b97ce2b52a1e89",
       "parent": null,
       "path": "format.js",
       "provenance": {
@@ -851,7 +851,7 @@
       },
       "qualified_name": null,
       "relationships": [],
-      "semantic_path": "tests/fixtures/boundary_ir/repos/javascript/format.js",
+      "semantic_path": "format.js",
       "signature": null,
       "span": {
         "byte_end": 60,
@@ -883,9 +883,9 @@
         ],
         "imports": [],
         "parent_symbol": null,
-        "semantic_text": "language: javascript\nfile: tests/fixtures/boundary_ir/repos/javascript/service.js\nkind: export_statement\nsemantic path: tests/fixtures/boundary_ir/repos/javascript/service.js\nexports: run\ndependencies: formatName, helper, missingCall\ncontent:\nexport function run(value) {\n  const cleaned = formatName(value);\n  const duplicate = helper(cleaned);\n  return missingCall(duplicate);\n}"
+        "semantic_text": "language: javascript\nfile: service.js\nkind: export_statement\nsemantic path: service.js\nexports: run\ndependencies: formatName, helper, missingCall\ncontent:\nexport function run(value) {\n  const cleaned = formatName(value);\n  const duplicate = helper(cleaned);\n  return missingCall(duplicate);\n}"
       },
-      "node_id": "fee72e89bc1f9d0d35028260430bcb8d1fc576cf",
+      "node_id": "499684ec51372ed18680e9154ae0de14595dadb4",
       "parent": null,
       "path": "service.js",
       "provenance": {
@@ -894,7 +894,7 @@
       },
       "qualified_name": null,
       "relationships": [],
-      "semantic_path": "tests/fixtures/boundary_ir/repos/javascript/service.js",
+      "semantic_path": "service.js",
       "signature": null,
       "span": {
         "byte_end": 259,
@@ -924,9 +924,9 @@
         ],
         "imports": [],
         "parent_symbol": null,
-        "semantic_text": "language: javascript\nfile: tests/fixtures/boundary_ir/repos/javascript/service.js\nkind: export_statement\nsemantic path: tests/fixtures/boundary_ir/repos/javascript/service.js\nexports: Renderer\ndependencies: formatName\ncontent:\nexport class Renderer {\n  render(value) {\n    return formatName(value);\n  }\n}"
+        "semantic_text": "language: javascript\nfile: service.js\nkind: export_statement\nsemantic path: service.js\nexports: Renderer\ndependencies: formatName\ncontent:\nexport class Renderer {\n  render(value) {\n    return formatName(value);\n  }\n}"
       },
-      "node_id": "fff010c9be63ef49e896b3b2681ed1c4fd9b8fb1",
+      "node_id": "547bae8a0fcd8921e21f8a4ba45f7983b23ced30",
       "parent": null,
       "path": "service.js",
       "provenance": {
@@ -935,7 +935,7 @@
       },
       "qualified_name": null,
       "relationships": [],
-      "semantic_path": "tests/fixtures/boundary_ir/repos/javascript/service.js",
+      "semantic_path": "service.js",
       "signature": null,
       "span": {
         "byte_end": 120,
@@ -964,10 +964,10 @@
         "exports": [],
         "imports": [],
         "parent_symbol": "run",
-        "semantic_text": "language: javascript\nfile: tests/fixtures/boundary_ir/repos/javascript/service.js\nkind: variable_declarator\nsymbol: duplicate\nqualified name: run.duplicate\nparent symbol: run\nsemantic path: tests/fixtures/boundary_ir/repos/javascript/service.js::run.duplicate\ndependencies: cleaned, helper\ncontent:\nduplicate = helper(cleaned)"
+        "semantic_text": "language: javascript\nfile: service.js\nkind: variable_declarator\nsymbol: duplicate\nqualified name: run.duplicate\nparent symbol: run\nsemantic path: service.js::run.duplicate\ndependencies: cleaned, helper\ncontent:\nduplicate = helper(cleaned)"
       },
-      "node_id": "3ff4b15739bf50c9817abd584f8a508d94eea8a2",
-      "parent": "9ee6f8c45786007268b21e77fa85d637bc93a56e",
+      "node_id": "7b1bd90fdea64b097dfaba2a6d7dfedc75e564c7",
+      "parent": "dcdb38178db8a5cb54fbcad7b71b42e47fff79f8",
       "path": "service.js",
       "provenance": {
         "extractor": "chunk_file",
@@ -975,7 +975,7 @@
       },
       "qualified_name": "run.duplicate",
       "relationships": [],
-      "semantic_path": "tests/fixtures/boundary_ir/repos/javascript/service.js::run.duplicate",
+      "semantic_path": "service.js::run.duplicate",
       "signature": null,
       "span": {
         "byte_end": 223,
@@ -984,7 +984,7 @@
         "start_line": 11
       },
       "symbol": "duplicate",
-      "symbol_id": "443e78f9469cb2116332934ef8c3977e39bc007c"
+      "symbol_id": "f51323e33a69a4c92e86aacd32ed81bef90d3915"
     }
   ],
   "run": {

--- a/tests/fixtures/boundary_ir/golden/python.json
+++ b/tests/fixtures/boundary_ir/golden/python.json
@@ -591,9 +591,9 @@
           "from app.formatting import format_name"
         ],
         "parent_symbol": null,
-        "semantic_text": "language: python\nfile: tests/fixtures/boundary_ir/repos/python/app/service.py\nkind: function\nsymbol: render_report\nqualified name: render_report\nsemantic path: tests/fixtures/boundary_ir/repos/python/app/service.py::render_report\nsignature text: render_report(value: str) -> str\nimports: from app.formatting import format_name\nexports: cleaned, duplicate, render_report, value\ndependencies: app, format_name, formatting, helper, missing_call\ncontent:\ndef render_report(value: str) -> str:\n    from app.formatting import format_name\n\n    cleaned = format_name(value)\n    duplicate = helper(cleaned)\n    return missing_call(duplicate)"
+        "semantic_text": "language: python\nfile: app/service.py\nkind: function\nsymbol: render_report\nqualified name: render_report\nsemantic path: app/service.py::render_report\nsignature text: render_report(value: str) -> str\nimports: from app.formatting import format_name\nexports: cleaned, duplicate, render_report, value\ndependencies: app, format_name, formatting, helper, missing_call\ncontent:\ndef render_report(value: str) -> str:\n    from app.formatting import format_name\n\n    cleaned = format_name(value)\n    duplicate = helper(cleaned)\n    return missing_call(duplicate)"
       },
-      "node_id": "3bf04a9618cf539f4695d3498876870f9cb277bd",
+      "node_id": "21b528f1c0d9a7fcfe9db58423d4b42a2d7eacde",
       "parent": null,
       "path": "app/service.py",
       "provenance": {
@@ -612,7 +612,7 @@
         "edge:c939173996241d72",
         "edge:e486738be6b910eb"
       ],
-      "semantic_path": "tests/fixtures/boundary_ir/repos/python/app/service.py::render_report",
+      "semantic_path": "app/service.py::render_report",
       "signature": "render_report(value: str) -> str",
       "span": {
         "byte_end": 315,
@@ -621,7 +621,7 @@
         "start_line": 9
       },
       "symbol": "render_report",
-      "symbol_id": "651827073930839f2df70237291968ae9348f4e2"
+      "symbol_id": "fc027cd18f8abead5f98b06926dd18162eb0757a"
     },
     {
       "definition_id": "43ddb130bf1b413b1406b1685ca631ef9f660f73",
@@ -644,10 +644,10 @@
         ],
         "imports": [],
         "parent_symbol": "Renderer",
-        "semantic_text": "language: python\nfile: tests/fixtures/boundary_ir/repos/python/app/service.py\nkind: method\nsymbol: render\nqualified name: Renderer.render\nparent symbol: Renderer\nsemantic path: tests/fixtures/boundary_ir/repos/python/app/service.py::Renderer.render\nsignature text: render(self, value: str) -> str\nexports: render, self, value\ndependencies: format_name\ncontent:\ndef render(self, value: str) -> str:\n        return format_name(value)"
+        "semantic_text": "language: python\nfile: app/service.py\nkind: method\nsymbol: render\nqualified name: Renderer.render\nparent symbol: Renderer\nsemantic path: app/service.py::Renderer.render\nsignature text: render(self, value: str) -> str\nexports: render, self, value\ndependencies: format_name\ncontent:\ndef render(self, value: str) -> str:\n        return format_name(value)"
       },
-      "node_id": "4c9f788d64a8f60b5336cdb110c049df2a958f98",
-      "parent": "c33bb72c5d141687a224f19d60aada2809d0e279",
+      "node_id": "1b645997804db41b8a8b76d1e53cf69d1ef0bcd0",
+      "parent": "0db901e789327c79fa0906b1ce0ba38e37180278",
       "path": "app/service.py",
       "provenance": {
         "extractor": "chunk_file",
@@ -658,7 +658,7 @@
         "edge:83e166bd1932e35e",
         "edge:b74e98f096722241"
       ],
-      "semantic_path": "tests/fixtures/boundary_ir/repos/python/app/service.py::Renderer.render",
+      "semantic_path": "app/service.py::Renderer.render",
       "signature": "render(self, value: str) -> str",
       "span": {
         "byte_end": 131,
@@ -667,7 +667,7 @@
         "start_line": 5
       },
       "symbol": "render",
-      "symbol_id": "d41453681d9251301cbaa98ac81b6296b0ca638f"
+      "symbol_id": "86d1db434cb91e4d9f0d14af15501a2df67e95be"
     },
     {
       "definition_id": "4597ccd545a95379c4793630374d4c9ec080f210",
@@ -691,9 +691,9 @@
         ],
         "imports": [],
         "parent_symbol": null,
-        "semantic_text": "language: python\nfile: tests/fixtures/boundary_ir/repos/python/app/service.py\nkind: class\nsymbol: Renderer\nqualified name: Renderer\nsemantic path: tests/fixtures/boundary_ir/repos/python/app/service.py::Renderer\nexports: Renderer, render, self, value\ndependencies: format_name\ncontent:\nclass Renderer:\n    def render(self, value: str) -> str:\n        return format_name(value)"
+        "semantic_text": "language: python\nfile: app/service.py\nkind: class\nsymbol: Renderer\nqualified name: Renderer\nsemantic path: app/service.py::Renderer\nexports: Renderer, render, self, value\ndependencies: format_name\ncontent:\nclass Renderer:\n    def render(self, value: str) -> str:\n        return format_name(value)"
       },
-      "node_id": "c33bb72c5d141687a224f19d60aada2809d0e279",
+      "node_id": "0db901e789327c79fa0906b1ce0ba38e37180278",
       "parent": null,
       "path": "app/service.py",
       "provenance": {
@@ -705,7 +705,7 @@
         "edge:1ae962a1d50bc8dd",
         "edge:c79637284d27493d"
       ],
-      "semantic_path": "tests/fixtures/boundary_ir/repos/python/app/service.py::Renderer",
+      "semantic_path": "app/service.py::Renderer",
       "signature": null,
       "span": {
         "byte_end": 131,
@@ -714,7 +714,7 @@
         "start_line": 4
       },
       "symbol": "Renderer",
-      "symbol_id": "725ff603dfdc648802565c16d13bb5bbd7a68b0e"
+      "symbol_id": "d9cae5d6c3757cf13aee2dcae458dd08b8e3eedf"
     },
     {
       "definition_id": "514ea25c032c544bfcb5cec28f107cd30478a06a",
@@ -736,9 +736,9 @@
         ],
         "imports": [],
         "parent_symbol": null,
-        "semantic_text": "language: python\nfile: tests/fixtures/boundary_ir/repos/python/app/formatting.py\nkind: function\nsymbol: format_name\nqualified name: format_name\nsemantic path: tests/fixtures/boundary_ir/repos/python/app/formatting.py::format_name\nsignature text: format_name(value: str) -> str\nexports: format_name, value\ndependencies: strip\ncontent:\ndef format_name(value: str) -> str:\n    return value.strip()"
+        "semantic_text": "language: python\nfile: app/formatting.py\nkind: function\nsymbol: format_name\nqualified name: format_name\nsemantic path: app/formatting.py::format_name\nsignature text: format_name(value: str) -> str\nexports: format_name, value\ndependencies: strip\ncontent:\ndef format_name(value: str) -> str:\n    return value.strip()"
       },
-      "node_id": "8a6dba12b4eb390f2c478eef00880fec1cb71c9a",
+      "node_id": "b46d949e343a88d97e31e067449517d8fd0a2cb6",
       "parent": null,
       "path": "app/formatting.py",
       "provenance": {
@@ -750,7 +750,7 @@
         "edge:11c0685beb40588a",
         "edge:ec7887dd18fc0294"
       ],
-      "semantic_path": "tests/fixtures/boundary_ir/repos/python/app/formatting.py::format_name",
+      "semantic_path": "app/formatting.py::format_name",
       "signature": "format_name(value: str) -> str",
       "span": {
         "byte_end": 60,
@@ -759,7 +759,7 @@
         "start_line": 1
       },
       "symbol": "format_name",
-      "symbol_id": "6c42022dd99db52d902697e7a94925a77c26bd42"
+      "symbol_id": "b2c1acac76441a50ff3c138573385269cb16a768"
     },
     {
       "definition_id": "64d77146b1952a48a00557eda87ad157160c62fd",
@@ -781,9 +781,9 @@
         ],
         "imports": [],
         "parent_symbol": null,
-        "semantic_text": "language: python\nfile: tests/fixtures/boundary_ir/repos/python/app/beta.py\nkind: function\nsymbol: helper\nqualified name: helper\nsemantic path: tests/fixtures/boundary_ir/repos/python/app/beta.py::helper\nsignature text: helper(value: str) -> str\nexports: helper, value\ndependencies: upper\ncontent:\ndef helper(value: str) -> str:\n    return value.upper()"
+        "semantic_text": "language: python\nfile: app/beta.py\nkind: function\nsymbol: helper\nqualified name: helper\nsemantic path: app/beta.py::helper\nsignature text: helper(value: str) -> str\nexports: helper, value\ndependencies: upper\ncontent:\ndef helper(value: str) -> str:\n    return value.upper()"
       },
-      "node_id": "b4becbb15df979b4932c7a606e0ca359a3cda8fc",
+      "node_id": "1fdf6b6e32fadc81e5f1fbb2361266ae9d3fa009",
       "parent": null,
       "path": "app/beta.py",
       "provenance": {
@@ -795,7 +795,7 @@
         "edge:3f1d3f247d2d7e4d",
         "edge:aa9ebb52708d20b8"
       ],
-      "semantic_path": "tests/fixtures/boundary_ir/repos/python/app/beta.py::helper",
+      "semantic_path": "app/beta.py::helper",
       "signature": "helper(value: str) -> str",
       "span": {
         "byte_end": 55,
@@ -804,7 +804,7 @@
         "start_line": 1
       },
       "symbol": "helper",
-      "symbol_id": "3bc086274fc57df40adcf28ad8d88016fa24a5ca"
+      "symbol_id": "c1cc1e0734796b20059f639e9266f33b833d1885"
     },
     {
       "definition_id": "bcc5782f607322036ce36c5389e40ad8fc121e50",
@@ -826,9 +826,9 @@
         ],
         "imports": [],
         "parent_symbol": null,
-        "semantic_text": "language: python\nfile: tests/fixtures/boundary_ir/repos/python/app/alpha.py\nkind: function\nsymbol: helper\nqualified name: helper\nsemantic path: tests/fixtures/boundary_ir/repos/python/app/alpha.py::helper\nsignature text: helper(value: str) -> str\nexports: helper, value\ndependencies: lower\ncontent:\ndef helper(value: str) -> str:\n    return value.lower()"
+        "semantic_text": "language: python\nfile: app/alpha.py\nkind: function\nsymbol: helper\nqualified name: helper\nsemantic path: app/alpha.py::helper\nsignature text: helper(value: str) -> str\nexports: helper, value\ndependencies: lower\ncontent:\ndef helper(value: str) -> str:\n    return value.lower()"
       },
-      "node_id": "2f19a554b944833cb15535653d100528a86578f2",
+      "node_id": "c45f63c6998c6541b0a5298630f4d36bdb189ef9",
       "parent": null,
       "path": "app/alpha.py",
       "provenance": {
@@ -840,7 +840,7 @@
         "edge:0612480fc79d07fd",
         "edge:0aeddf939ef8fe99"
       ],
-      "semantic_path": "tests/fixtures/boundary_ir/repos/python/app/alpha.py::helper",
+      "semantic_path": "app/alpha.py::helper",
       "signature": "helper(value: str) -> str",
       "span": {
         "byte_end": 55,
@@ -849,7 +849,7 @@
         "start_line": 1
       },
       "symbol": "helper",
-      "symbol_id": "27f7bff0a7b67b7d6edaf353c57e3553a01d176d"
+      "symbol_id": "c59cb6d857c5a32c74f5be068ef19eaf4730ec4d"
     }
   ],
   "run": {

--- a/tests/fixtures/boundary_ir/golden/typescript.json
+++ b/tests/fixtures/boundary_ir/golden/typescript.json
@@ -649,10 +649,10 @@
         ],
         "imports": [],
         "parent_symbol": null,
-        "semantic_text": "language: typescript\nfile: tests/fixtures/boundary_ir/repos/typescript/format.ts\nkind: interface\nsymbol: Formatter\nqualified name: Formatter\nsemantic path: tests/fixtures/boundary_ir/repos/typescript/format.ts::Formatter\nexports: Formatter\ndependencies: Formatter, value\ncontent:\ninterface Formatter {\n  render(value: string): string;\n}"
+        "semantic_text": "language: typescript\nfile: format.ts\nkind: interface\nsymbol: Formatter\nqualified name: Formatter\nsemantic path: format.ts::Formatter\nexports: Formatter\ndependencies: Formatter, value\ncontent:\ninterface Formatter {\n  render(value: string): string;\n}"
       },
-      "node_id": "238c4c1492bc3a2aac021e800ba593ca44a30277",
-      "parent": "684143484f00207d265ee2ec796339e4a20038fd",
+      "node_id": "6a664e15701e96fed3e1e6272edbed693402291a",
+      "parent": "679d7b11e5e4f043797f26bed8abfd8ef0b14550",
       "path": "format.ts",
       "provenance": {
         "extractor": "chunk_file",
@@ -662,7 +662,7 @@
       "relationships": [
         "edge:b56face9b188cb68"
       ],
-      "semantic_path": "tests/fixtures/boundary_ir/repos/typescript/format.ts::Formatter",
+      "semantic_path": "format.ts::Formatter",
       "signature": null,
       "span": {
         "byte_end": 63,
@@ -671,7 +671,7 @@
         "start_line": 1
       },
       "symbol": "Formatter",
-      "symbol_id": "d9bca8ba28ab0a5dd7ff4ee2b824f0d160386e1e"
+      "symbol_id": "1e138db7afc4edb494e8539ca6deb27b78c81255"
     },
     {
       "definition_id": "300f24d511ea9337e2f0d1dd43c03236cfc30535",
@@ -691,9 +691,9 @@
         "exports": [],
         "imports": [],
         "parent_symbol": null,
-        "semantic_text": "language: typescript\nfile: tests/fixtures/boundary_ir/repos/typescript/format.ts\nkind: export_statement\nsemantic path: tests/fixtures/boundary_ir/repos/typescript/format.ts\ndependencies: Formatter, value\ncontent:\nexport interface Formatter {\n  render(value: string): string;\n}"
+        "semantic_text": "language: typescript\nfile: format.ts\nkind: export_statement\nsemantic path: format.ts\ndependencies: Formatter, value\ncontent:\nexport interface Formatter {\n  render(value: string): string;\n}"
       },
-      "node_id": "684143484f00207d265ee2ec796339e4a20038fd",
+      "node_id": "679d7b11e5e4f043797f26bed8abfd8ef0b14550",
       "parent": null,
       "path": "format.ts",
       "provenance": {
@@ -702,7 +702,7 @@
       },
       "qualified_name": null,
       "relationships": [],
-      "semantic_path": "tests/fixtures/boundary_ir/repos/typescript/format.ts",
+      "semantic_path": "format.ts",
       "signature": null,
       "span": {
         "byte_end": 63,
@@ -733,9 +733,9 @@
           "{ Formatter }"
         ],
         "parent_symbol": null,
-        "semantic_text": "language: typescript\nfile: tests/fixtures/boundary_ir/repos/typescript/service.ts\nkind: import_statement\nsemantic path: tests/fixtures/boundary_ir/repos/typescript/service.ts\nimports: import type { Formatter } from './format';, { Formatter }\ndependencies: Formatter\ncontent:\nimport type { Formatter } from './format';"
+        "semantic_text": "language: typescript\nfile: service.ts\nkind: import_statement\nsemantic path: service.ts\nimports: import type { Formatter } from './format';, { Formatter }\ndependencies: Formatter\ncontent:\nimport type { Formatter } from './format';"
       },
-      "node_id": "eeeb1aed3f4c0f157d7ebb1d15c5f12645657c7c",
+      "node_id": "f66de88e5a1936d0c68d64ec4a79e6c9d16b15b8",
       "parent": null,
       "path": "service.ts",
       "provenance": {
@@ -744,7 +744,7 @@
       },
       "qualified_name": null,
       "relationships": [],
-      "semantic_path": "tests/fixtures/boundary_ir/repos/typescript/service.ts",
+      "semantic_path": "service.ts",
       "signature": null,
       "span": {
         "byte_end": 81,
@@ -774,10 +774,10 @@
         ],
         "imports": [],
         "parent_symbol": null,
-        "semantic_text": "language: typescript\nfile: tests/fixtures/boundary_ir/repos/typescript/beta.ts\nkind: function\nsymbol: helper\nqualified name: helper\nsemantic path: tests/fixtures/boundary_ir/repos/typescript/beta.ts::helper\nsignature text: helper(value: string) -> string\nexports: helper\ndependencies: value\ncontent:\nfunction helper(value: string): string {\n  return value.toUpperCase();\n}"
+        "semantic_text": "language: typescript\nfile: beta.ts\nkind: function\nsymbol: helper\nqualified name: helper\nsemantic path: beta.ts::helper\nsignature text: helper(value: string) -> string\nexports: helper\ndependencies: value\ncontent:\nfunction helper(value: string): string {\n  return value.toUpperCase();\n}"
       },
-      "node_id": "b48860251b799f747aed0a0bbabfe0efc318b4db",
-      "parent": "facaeb3115646069680ec332a144d88d93c3b196",
+      "node_id": "825b2d0e001862de7ab76aefed0fb94d0302f81e",
+      "parent": "06e611699402a47a5531cc1db21529f8e6081992",
       "path": "beta.ts",
       "provenance": {
         "extractor": "chunk_file",
@@ -788,7 +788,7 @@
         "edge:24da3f3f0e92cb97",
         "edge:405e6a506b2ed3b5"
       ],
-      "semantic_path": "tests/fixtures/boundary_ir/repos/typescript/beta.ts::helper",
+      "semantic_path": "beta.ts::helper",
       "signature": "helper(value: string) -> string",
       "span": {
         "byte_end": 79,
@@ -797,7 +797,7 @@
         "start_line": 1
       },
       "symbol": "helper",
-      "symbol_id": "3cc3973a64858dd5368bcf9cc62d463710b62301"
+      "symbol_id": "41ab513915d72fa8507790cce1e366d6330a5a95"
     },
     {
       "definition_id": "3be965d6638f473ebcc93e819b6749480a9e160c",
@@ -818,9 +818,9 @@
         ],
         "imports": [],
         "parent_symbol": null,
-        "semantic_text": "language: typescript\nfile: tests/fixtures/boundary_ir/repos/typescript/beta.ts\nkind: export_statement\nsemantic path: tests/fixtures/boundary_ir/repos/typescript/beta.ts\nexports: helper\ndependencies: value\ncontent:\nexport function helper(value: string): string {\n  return value.toUpperCase();\n}"
+        "semantic_text": "language: typescript\nfile: beta.ts\nkind: export_statement\nsemantic path: beta.ts\nexports: helper\ndependencies: value\ncontent:\nexport function helper(value: string): string {\n  return value.toUpperCase();\n}"
       },
-      "node_id": "facaeb3115646069680ec332a144d88d93c3b196",
+      "node_id": "06e611699402a47a5531cc1db21529f8e6081992",
       "parent": null,
       "path": "beta.ts",
       "provenance": {
@@ -829,7 +829,7 @@
       },
       "qualified_name": null,
       "relationships": [],
-      "semantic_path": "tests/fixtures/boundary_ir/repos/typescript/beta.ts",
+      "semantic_path": "beta.ts",
       "signature": null,
       "span": {
         "byte_end": 79,
@@ -859,10 +859,10 @@
         ],
         "imports": [],
         "parent_symbol": null,
-        "semantic_text": "language: typescript\nfile: tests/fixtures/boundary_ir/repos/typescript/format.ts\nkind: function\nsymbol: formatName\nqualified name: formatName\nsemantic path: tests/fixtures/boundary_ir/repos/typescript/format.ts::formatName\nsignature text: formatName(value: string) -> string\nexports: formatName\ndependencies: value\ncontent:\nfunction formatName(value: string): string {\n  return value.trim();\n}"
+        "semantic_text": "language: typescript\nfile: format.ts\nkind: function\nsymbol: formatName\nqualified name: formatName\nsemantic path: format.ts::formatName\nsignature text: formatName(value: string) -> string\nexports: formatName\ndependencies: value\ncontent:\nfunction formatName(value: string): string {\n  return value.trim();\n}"
       },
-      "node_id": "a2525ef5e39a2671a3024d281045a4083e2e2920",
-      "parent": "14b46336878e2ead68fc6c33adfb8c50a87d4f41",
+      "node_id": "a9a79bcaf2e61c01d187d2802314ca10307eb87a",
+      "parent": "99b0435475b7e790a4e9c234374aa50cc88fe4e0",
       "path": "format.ts",
       "provenance": {
         "extractor": "chunk_file",
@@ -873,7 +873,7 @@
         "edge:83a1c049e249274f",
         "edge:87ab3daa177569e4"
       ],
-      "semantic_path": "tests/fixtures/boundary_ir/repos/typescript/format.ts::formatName",
+      "semantic_path": "format.ts::formatName",
       "signature": "formatName(value: string) -> string",
       "span": {
         "byte_end": 141,
@@ -882,7 +882,7 @@
         "start_line": 5
       },
       "symbol": "formatName",
-      "symbol_id": "3bf7a8f4290ef6f6ae990b2468beba981049c15e"
+      "symbol_id": "00d2ad772e8e030b5e19e6d71f96ea775c09757d"
     },
     {
       "definition_id": "5c480181dd47eb87dfa3b365d0a727d9a86005cc",
@@ -904,10 +904,10 @@
         "exports": [],
         "imports": [],
         "parent_symbol": null,
-        "semantic_text": "language: typescript\nfile: tests/fixtures/boundary_ir/repos/typescript/service.ts\nkind: class\nsymbol: Renderer\nqualified name: Renderer\nsemantic path: tests/fixtures/boundary_ir/repos/typescript/service.ts::Renderer\ndependencies: Formatter, Renderer, formatName, value\ncontent:\nclass Renderer implements Formatter {\n  render(value: string): string {\n    return formatName(value);\n  }\n}"
+        "semantic_text": "language: typescript\nfile: service.ts\nkind: class\nsymbol: Renderer\nqualified name: Renderer\nsemantic path: service.ts::Renderer\ndependencies: Formatter, Renderer, formatName, value\ncontent:\nclass Renderer implements Formatter {\n  render(value: string): string {\n    return formatName(value);\n  }\n}"
       },
-      "node_id": "839b492410f06baeab0894061a60e760e97dfd83",
-      "parent": "d3aa11f82bfc443f54849d087f31be38d7280d3c",
+      "node_id": "2b7844da3a7b6cefc91369f6207c87866eddda6f",
+      "parent": "5537a2a537896436b04ec5b32421d7ce7a976bac",
       "path": "service.ts",
       "provenance": {
         "extractor": "chunk_file",
@@ -920,7 +920,7 @@
         "edge:1fb97e4a31ce4359",
         "edge:6644f60a5e273567"
       ],
-      "semantic_path": "tests/fixtures/boundary_ir/repos/typescript/service.ts::Renderer",
+      "semantic_path": "service.ts::Renderer",
       "signature": null,
       "span": {
         "byte_end": 197,
@@ -929,7 +929,7 @@
         "start_line": 4
       },
       "symbol": "Renderer",
-      "symbol_id": "470cb0b070dc4ae6d47d5b11beaccea4cbec474f"
+      "symbol_id": "6acefe05731d0e61dc084a56741188cfea13fe1f"
     },
     {
       "definition_id": "7a25a07906ad66111659f05d4414846605a357e7",
@@ -951,10 +951,10 @@
         ],
         "imports": [],
         "parent_symbol": "Renderer",
-        "semantic_text": "language: typescript\nfile: tests/fixtures/boundary_ir/repos/typescript/service.ts\nkind: method\nsymbol: render\nqualified name: Renderer.render\nparent symbol: Renderer\nsemantic path: tests/fixtures/boundary_ir/repos/typescript/service.ts::Renderer.render\nsignature text: render(value: string) -> string\nexports: render\ndependencies: formatName, value\ncontent:\nrender(value: string): string {\n    return formatName(value);\n  }"
+        "semantic_text": "language: typescript\nfile: service.ts\nkind: method\nsymbol: render\nqualified name: Renderer.render\nparent symbol: Renderer\nsemantic path: service.ts::Renderer.render\nsignature text: render(value: string) -> string\nexports: render\ndependencies: formatName, value\ncontent:\nrender(value: string): string {\n    return formatName(value);\n  }"
       },
-      "node_id": "39989bdce346334adbec8303390bf21c3d12800c",
-      "parent": "839b492410f06baeab0894061a60e760e97dfd83",
+      "node_id": "87a143587e2759db926b7072e0c96b309cc842e5",
+      "parent": "2b7844da3a7b6cefc91369f6207c87866eddda6f",
       "path": "service.ts",
       "provenance": {
         "extractor": "chunk_file",
@@ -966,7 +966,7 @@
         "edge:3f2d65f324966438",
         "edge:e05b2e490a2ab53d"
       ],
-      "semantic_path": "tests/fixtures/boundary_ir/repos/typescript/service.ts::Renderer.render",
+      "semantic_path": "service.ts::Renderer.render",
       "signature": "render(value: string) -> string",
       "span": {
         "byte_end": 195,
@@ -975,7 +975,7 @@
         "start_line": 5
       },
       "symbol": "render",
-      "symbol_id": "ff85493be6564ba4af5892ea52bc5b32e0722501"
+      "symbol_id": "0ee42e1dc72339752543cf2fe83802e5ed6de432"
     },
     {
       "definition_id": "8e7396d6bec9475cffe0bbe3165ce72d7cd5418a",
@@ -996,9 +996,9 @@
         ],
         "imports": [],
         "parent_symbol": null,
-        "semantic_text": "language: typescript\nfile: tests/fixtures/boundary_ir/repos/typescript/alpha.ts\nkind: export_statement\nsemantic path: tests/fixtures/boundary_ir/repos/typescript/alpha.ts\nexports: helper\ndependencies: value\ncontent:\nexport function helper(value: string): string {\n  return value.toLowerCase();\n}"
+        "semantic_text": "language: typescript\nfile: alpha.ts\nkind: export_statement\nsemantic path: alpha.ts\nexports: helper\ndependencies: value\ncontent:\nexport function helper(value: string): string {\n  return value.toLowerCase();\n}"
       },
-      "node_id": "39271ec75a549cbd6662ef0597cf393813c4d10c",
+      "node_id": "d749e3742ec7aebabc5c31d3a78df92aa1be2766",
       "parent": null,
       "path": "alpha.ts",
       "provenance": {
@@ -1007,7 +1007,7 @@
       },
       "qualified_name": null,
       "relationships": [],
-      "semantic_path": "tests/fixtures/boundary_ir/repos/typescript/alpha.ts",
+      "semantic_path": "alpha.ts",
       "signature": null,
       "span": {
         "byte_end": 79,
@@ -1040,10 +1040,10 @@
         ],
         "imports": [],
         "parent_symbol": null,
-        "semantic_text": "language: typescript\nfile: tests/fixtures/boundary_ir/repos/typescript/service.ts\nkind: function\nsymbol: run\nqualified name: run\nsemantic path: tests/fixtures/boundary_ir/repos/typescript/service.ts::run\nsignature text: run(value: string) -> string\nexports: run\ndependencies: formatName, helper, missingCall, value\ncontent:\nfunction run(value: string): string {\n  const cleaned = formatName(value);\n  const duplicate = helper(cleaned);\n  return missingCall(duplicate);\n}"
+        "semantic_text": "language: typescript\nfile: service.ts\nkind: function\nsymbol: run\nqualified name: run\nsemantic path: service.ts::run\nsignature text: run(value: string) -> string\nexports: run\ndependencies: formatName, helper, missingCall, value\ncontent:\nfunction run(value: string): string {\n  const cleaned = formatName(value);\n  const duplicate = helper(cleaned);\n  return missingCall(duplicate);\n}"
       },
-      "node_id": "2e7d34a3db0c2e27475afdbc3968eb094ce15ef6",
-      "parent": "00157bd9693b01de427d99279ae8fb2a37a7f470",
+      "node_id": "8c2786f53f96d651d376844356f0253d0b13f118",
+      "parent": "76383a50628f366dd3136bf6b0e8de1a27720bd0",
       "path": "service.ts",
       "provenance": {
         "extractor": "chunk_file",
@@ -1059,7 +1059,7 @@
         "edge:f69393eaeb31d904",
         "edge:fa49b2d630eb244a"
       ],
-      "semantic_path": "tests/fixtures/boundary_ir/repos/typescript/service.ts::run",
+      "semantic_path": "service.ts::run",
       "signature": "run(value: string) -> string",
       "span": {
         "byte_end": 352,
@@ -1068,7 +1068,7 @@
         "start_line": 10
       },
       "symbol": "run",
-      "symbol_id": "db865db7200d0d0a5c1b60cb686de4d2ba5fa9ca"
+      "symbol_id": "d69adde6fb2260b23d5c623709f8de5315dbc901"
     },
     {
       "definition_id": "ae7d4305baeb6e87e8f3fd6e9eb335216aad45fe",
@@ -1088,10 +1088,10 @@
         "exports": [],
         "imports": [],
         "parent_symbol": "run",
-        "semantic_text": "language: typescript\nfile: tests/fixtures/boundary_ir/repos/typescript/service.ts\nkind: variable_declarator\nsymbol: duplicate\nqualified name: run.duplicate\nparent symbol: run\nsemantic path: tests/fixtures/boundary_ir/repos/typescript/service.ts::run.duplicate\ndependencies: cleaned, helper\ncontent:\nduplicate = helper(cleaned)"
+        "semantic_text": "language: typescript\nfile: service.ts\nkind: variable_declarator\nsymbol: duplicate\nqualified name: run.duplicate\nparent symbol: run\nsemantic path: service.ts::run.duplicate\ndependencies: cleaned, helper\ncontent:\nduplicate = helper(cleaned)"
       },
-      "node_id": "6268dac5e7757000c855c04a7a0e1bc0197d4bd7",
-      "parent": "2e7d34a3db0c2e27475afdbc3968eb094ce15ef6",
+      "node_id": "cfddf23437e21252badc21378b2be74e053ca6bd",
+      "parent": "8c2786f53f96d651d376844356f0253d0b13f118",
       "path": "service.ts",
       "provenance": {
         "extractor": "chunk_file",
@@ -1099,7 +1099,7 @@
       },
       "qualified_name": "run.duplicate",
       "relationships": [],
-      "semantic_path": "tests/fixtures/boundary_ir/repos/typescript/service.ts::run.duplicate",
+      "semantic_path": "service.ts::run.duplicate",
       "signature": null,
       "span": {
         "byte_end": 316,
@@ -1108,7 +1108,7 @@
         "start_line": 12
       },
       "symbol": "duplicate",
-      "symbol_id": "925e93582f895bd8c9255120224b6de8ebf586cb"
+      "symbol_id": "3a4bc5a49520e1a9c13c1e7437bc3affd9f19fec"
     },
     {
       "definition_id": "b62589f30f88c80902a6a346e174807a80fadbdd",
@@ -1129,9 +1129,9 @@
         ],
         "imports": [],
         "parent_symbol": null,
-        "semantic_text": "language: typescript\nfile: tests/fixtures/boundary_ir/repos/typescript/format.ts\nkind: export_statement\nsemantic path: tests/fixtures/boundary_ir/repos/typescript/format.ts\nexports: formatName\ndependencies: value\ncontent:\nexport function formatName(value: string): string {\n  return value.trim();\n}"
+        "semantic_text": "language: typescript\nfile: format.ts\nkind: export_statement\nsemantic path: format.ts\nexports: formatName\ndependencies: value\ncontent:\nexport function formatName(value: string): string {\n  return value.trim();\n}"
       },
-      "node_id": "14b46336878e2ead68fc6c33adfb8c50a87d4f41",
+      "node_id": "99b0435475b7e790a4e9c234374aa50cc88fe4e0",
       "parent": null,
       "path": "format.ts",
       "provenance": {
@@ -1140,7 +1140,7 @@
       },
       "qualified_name": null,
       "relationships": [],
-      "semantic_path": "tests/fixtures/boundary_ir/repos/typescript/format.ts",
+      "semantic_path": "format.ts",
       "signature": null,
       "span": {
         "byte_end": 141,
@@ -1168,10 +1168,10 @@
         "exports": [],
         "imports": [],
         "parent_symbol": "Formatter",
-        "semantic_text": "language: typescript\nfile: tests/fixtures/boundary_ir/repos/typescript/format.ts\nkind: method\nsymbol: render\nqualified name: Formatter.render\nparent symbol: Formatter\nsemantic path: tests/fixtures/boundary_ir/repos/typescript/format.ts::Formatter.render\ndependencies: value\ncontent:\nrender(value: string): string"
+        "semantic_text": "language: typescript\nfile: format.ts\nkind: method\nsymbol: render\nqualified name: Formatter.render\nparent symbol: Formatter\nsemantic path: format.ts::Formatter.render\ndependencies: value\ncontent:\nrender(value: string): string"
       },
-      "node_id": "a7995e979fe35153ea7d49bbf8e70fdb6f40b68b",
-      "parent": "238c4c1492bc3a2aac021e800ba593ca44a30277",
+      "node_id": "29f0d8415d3edde61282805ce22c46db9db52bc4",
+      "parent": "6a664e15701e96fed3e1e6272edbed693402291a",
       "path": "format.ts",
       "provenance": {
         "extractor": "chunk_file",
@@ -1181,7 +1181,7 @@
       "relationships": [
         "edge:024a39166f1dcccd"
       ],
-      "semantic_path": "tests/fixtures/boundary_ir/repos/typescript/format.ts::Formatter.render",
+      "semantic_path": "format.ts::Formatter.render",
       "signature": null,
       "span": {
         "byte_end": 60,
@@ -1190,7 +1190,7 @@
         "start_line": 2
       },
       "symbol": "render",
-      "symbol_id": "4dc3e86db5eef2c898b853564aa7c9800c6c39e6"
+      "symbol_id": "d11e1eeaab64839fef8da081d4356f437fc9cdbb"
     },
     {
       "definition_id": "cf491cce00b6d9dddf5651d64712a96ba7a575b1",
@@ -1210,10 +1210,10 @@
         "exports": [],
         "imports": [],
         "parent_symbol": "run",
-        "semantic_text": "language: typescript\nfile: tests/fixtures/boundary_ir/repos/typescript/service.ts\nkind: variable_declarator\nsymbol: cleaned\nqualified name: run.cleaned\nparent symbol: run\nsemantic path: tests/fixtures/boundary_ir/repos/typescript/service.ts::run.cleaned\ndependencies: formatName, value\ncontent:\ncleaned = formatName(value)"
+        "semantic_text": "language: typescript\nfile: service.ts\nkind: variable_declarator\nsymbol: cleaned\nqualified name: run.cleaned\nparent symbol: run\nsemantic path: service.ts::run.cleaned\ndependencies: formatName, value\ncontent:\ncleaned = formatName(value)"
       },
-      "node_id": "f4ff21610e12c954c88f9bf34b0090187b995cc1",
-      "parent": "2e7d34a3db0c2e27475afdbc3968eb094ce15ef6",
+      "node_id": "aea4108f6bd076b468a0491f39e1496e3a1a1679",
+      "parent": "8c2786f53f96d651d376844356f0253d0b13f118",
       "path": "service.ts",
       "provenance": {
         "extractor": "chunk_file",
@@ -1221,7 +1221,7 @@
       },
       "qualified_name": "run.cleaned",
       "relationships": [],
-      "semantic_path": "tests/fixtures/boundary_ir/repos/typescript/service.ts::run.cleaned",
+      "semantic_path": "service.ts::run.cleaned",
       "signature": null,
       "span": {
         "byte_end": 279,
@@ -1230,7 +1230,7 @@
         "start_line": 11
       },
       "symbol": "cleaned",
-      "symbol_id": "6a0abd55ae61d6f5f134fdd6b776c55561b2b18e"
+      "symbol_id": "31feb4bda94d5410f7ae0e79c25a9cf02d432f5d"
     },
     {
       "definition_id": "d30b3d9e8b2c68aacf780d9c285fd0ef61cadf6a",
@@ -1251,10 +1251,10 @@
         ],
         "imports": [],
         "parent_symbol": null,
-        "semantic_text": "language: typescript\nfile: tests/fixtures/boundary_ir/repos/typescript/alpha.ts\nkind: function\nsymbol: helper\nqualified name: helper\nsemantic path: tests/fixtures/boundary_ir/repos/typescript/alpha.ts::helper\nsignature text: helper(value: string) -> string\nexports: helper\ndependencies: value\ncontent:\nfunction helper(value: string): string {\n  return value.toLowerCase();\n}"
+        "semantic_text": "language: typescript\nfile: alpha.ts\nkind: function\nsymbol: helper\nqualified name: helper\nsemantic path: alpha.ts::helper\nsignature text: helper(value: string) -> string\nexports: helper\ndependencies: value\ncontent:\nfunction helper(value: string): string {\n  return value.toLowerCase();\n}"
       },
-      "node_id": "8e2ab2d1c69688990b0550f80871d1553c51ce9a",
-      "parent": "39271ec75a549cbd6662ef0597cf393813c4d10c",
+      "node_id": "f8c0b614df1921dfd1df602f1e6cf09ecf1680dc",
+      "parent": "d749e3742ec7aebabc5c31d3a78df92aa1be2766",
       "path": "alpha.ts",
       "provenance": {
         "extractor": "chunk_file",
@@ -1265,7 +1265,7 @@
         "edge:af460caf7d857ac3",
         "edge:fbd7256751a1592e"
       ],
-      "semantic_path": "tests/fixtures/boundary_ir/repos/typescript/alpha.ts::helper",
+      "semantic_path": "alpha.ts::helper",
       "signature": "helper(value: string) -> string",
       "span": {
         "byte_end": 79,
@@ -1274,7 +1274,7 @@
         "start_line": 1
       },
       "symbol": "helper",
-      "symbol_id": "8ea3d9f72eaf5c5a7bd15cf2998ee564262905d6"
+      "symbol_id": "01f1f0aa9a917286091acf8f2c534bdf554969a9"
     },
     {
       "definition_id": "f8193d9b9ffa7361233822bc9e64ae508f2a1789",
@@ -1296,9 +1296,9 @@
           "{ formatName }"
         ],
         "parent_symbol": null,
-        "semantic_text": "language: typescript\nfile: tests/fixtures/boundary_ir/repos/typescript/service.ts\nkind: import_statement\nsemantic path: tests/fixtures/boundary_ir/repos/typescript/service.ts\nimports: import { formatName } from './format';, { formatName }\ndependencies: formatName\ncontent:\nimport { formatName } from './format';"
+        "semantic_text": "language: typescript\nfile: service.ts\nkind: import_statement\nsemantic path: service.ts\nimports: import { formatName } from './format';, { formatName }\ndependencies: formatName\ncontent:\nimport { formatName } from './format';"
       },
-      "node_id": "b55f7753c0cf1f59b0a87880e89d86ad5cbd6260",
+      "node_id": "4567799234eafbc419007ba1ca344c765f40e8e2",
       "parent": null,
       "path": "service.ts",
       "provenance": {
@@ -1307,7 +1307,7 @@
       },
       "qualified_name": null,
       "relationships": [],
-      "semantic_path": "tests/fixtures/boundary_ir/repos/typescript/service.ts",
+      "semantic_path": "service.ts",
       "signature": null,
       "span": {
         "byte_end": 38,
@@ -1338,9 +1338,9 @@
         "exports": [],
         "imports": [],
         "parent_symbol": null,
-        "semantic_text": "language: typescript\nfile: tests/fixtures/boundary_ir/repos/typescript/service.ts\nkind: export_statement\nsemantic path: tests/fixtures/boundary_ir/repos/typescript/service.ts\ndependencies: Formatter, Renderer, formatName, value\ncontent:\nexport class Renderer implements Formatter {\n  render(value: string): string {\n    return formatName(value);\n  }\n}"
+        "semantic_text": "language: typescript\nfile: service.ts\nkind: export_statement\nsemantic path: service.ts\ndependencies: Formatter, Renderer, formatName, value\ncontent:\nexport class Renderer implements Formatter {\n  render(value: string): string {\n    return formatName(value);\n  }\n}"
       },
-      "node_id": "d3aa11f82bfc443f54849d087f31be38d7280d3c",
+      "node_id": "5537a2a537896436b04ec5b32421d7ce7a976bac",
       "parent": null,
       "path": "service.ts",
       "provenance": {
@@ -1349,7 +1349,7 @@
       },
       "qualified_name": null,
       "relationships": [],
-      "semantic_path": "tests/fixtures/boundary_ir/repos/typescript/service.ts",
+      "semantic_path": "service.ts",
       "signature": null,
       "span": {
         "byte_end": 197,
@@ -1382,9 +1382,9 @@
         ],
         "imports": [],
         "parent_symbol": null,
-        "semantic_text": "language: typescript\nfile: tests/fixtures/boundary_ir/repos/typescript/service.ts\nkind: export_statement\nsemantic path: tests/fixtures/boundary_ir/repos/typescript/service.ts\nexports: run\ndependencies: formatName, helper, missingCall, value\ncontent:\nexport function run(value: string): string {\n  const cleaned = formatName(value);\n  const duplicate = helper(cleaned);\n  return missingCall(duplicate);\n}"
+        "semantic_text": "language: typescript\nfile: service.ts\nkind: export_statement\nsemantic path: service.ts\nexports: run\ndependencies: formatName, helper, missingCall, value\ncontent:\nexport function run(value: string): string {\n  const cleaned = formatName(value);\n  const duplicate = helper(cleaned);\n  return missingCall(duplicate);\n}"
       },
-      "node_id": "00157bd9693b01de427d99279ae8fb2a37a7f470",
+      "node_id": "76383a50628f366dd3136bf6b0e8de1a27720bd0",
       "parent": null,
       "path": "service.ts",
       "provenance": {
@@ -1393,7 +1393,7 @@
       },
       "qualified_name": null,
       "relationships": [],
-      "semantic_path": "tests/fixtures/boundary_ir/repos/typescript/service.ts",
+      "semantic_path": "service.ts",
       "signature": null,
       "span": {
         "byte_end": 352,

--- a/tests/fixtures/canon-vectors.json
+++ b/tests/fixtures/canon-vectors.json
@@ -1,0 +1,467 @@
+[
+  {
+    "name": "object-keys-sorted",
+    "input": {
+      "$obj": {
+        "b": {
+          "$int": "2"
+        },
+        "a": {
+          "$int": "1"
+        },
+        "c": {
+          "$int": "3"
+        }
+      }
+    },
+    "profile": "semantic-content",
+    "expected_canonical_bytes_b64": "eyJhIjoxLCJiIjoyLCJjIjozfQ==",
+    "expected_digest_hex": "0cf519811e261f23345f1ca861e24b1292d82f7f7f88dfc212950c52641b9435"
+  },
+  {
+    "name": "object-keys-sorted-reordered",
+    "input": {
+      "$obj": {
+        "c": {
+          "$int": "3"
+        },
+        "a": {
+          "$int": "1"
+        },
+        "b": {
+          "$int": "2"
+        }
+      }
+    },
+    "profile": "semantic-content",
+    "expected_canonical_bytes_b64": "eyJhIjoxLCJiIjoyLCJjIjozfQ==",
+    "expected_digest_hex": "0cf519811e261f23345f1ca861e24b1292d82f7f7f88dfc212950c52641b9435"
+  },
+  {
+    "name": "array-order-preserved",
+    "input": {
+      "$arr": [
+        {
+          "$int": "1"
+        },
+        {
+          "$int": "2"
+        },
+        {
+          "$int": "3"
+        }
+      ]
+    },
+    "profile": "semantic-content",
+    "expected_canonical_bytes_b64": "WzEsMiwzXQ==",
+    "expected_digest_hex": "79513425108f1e606d8ebe9351b94cedbd79ca6a3ac2c93b7f84a736386ff1c3"
+  },
+  {
+    "name": "array-order-matters",
+    "input": {
+      "$arr": [
+        {
+          "$int": "3"
+        },
+        {
+          "$int": "2"
+        },
+        {
+          "$int": "1"
+        }
+      ]
+    },
+    "profile": "semantic-content",
+    "expected_canonical_bytes_b64": "WzMsMiwxXQ==",
+    "expected_digest_hex": "959bf0b540a39de71c93f57a86bfd1402f8f0aa8ad52fb1270282ae7b9954d66"
+  },
+  {
+    "name": "nfc-composed-eacute",
+    "input": {
+      "$str": "\u00e9"
+    },
+    "profile": "semantic-content",
+    "expected_canonical_bytes_b64": "IsOpIg==",
+    "expected_digest_hex": "c9dcdb8c0beab390b15d6611cd3bd415b0df430bb7d6f6cb725ea5fe2b3588b7"
+  },
+  {
+    "name": "nfc-decomposed-eacute",
+    "input": {
+      "$str": "e\u0301"
+    },
+    "profile": "semantic-content",
+    "expected_canonical_bytes_b64": "IsOpIg==",
+    "expected_digest_hex": "c9dcdb8c0beab390b15d6611cd3bd415b0df430bb7d6f6cb725ea5fe2b3588b7"
+  },
+  {
+    "name": "nfc-key-normalized",
+    "input": {
+      "$obj": {
+        "e\u0301": {
+          "$int": "1"
+        }
+      }
+    },
+    "profile": "semantic-content",
+    "expected_canonical_bytes_b64": "eyLDqSI6MX0=",
+    "expected_digest_hex": "7997a063a1ea2e61680f762922fe089f3a2227ffd0aca1c5309dba0059604c80"
+  },
+  {
+    "name": "post13-nfc-reorder-telugu-nukta",
+    "input": {
+      "$str": "\u0c15\u0951\u0c3c"
+    },
+    "profile": "semantic-content",
+    "note": "U+0C3C(ccc7, U15.0) reorders before U+0951(ccc230); diverges under a U13 DB",
+    "expected_canonical_bytes_b64": "IuCwleCwvOClkSI=",
+    "expected_digest_hex": "b09dbd2a03fccaef40555ca0d4ee2ab9c1f5ceb3b3964a0806d296f357789de5"
+  },
+  {
+    "name": "post13-nfc-reorder-arabic-pepet",
+    "input": {
+      "$str": "\u0628\u0897\u065c"
+    },
+    "profile": "semantic-content",
+    "note": "U+0897 PEPET(ccc230, U16.0) reorders after U+065C(ccc220); diverges under U13",
+    "expected_canonical_bytes_b64": "Itio2Zzgopci",
+    "expected_digest_hex": "20468b80d250b26b4fc6fc2abd659e015de0bbe964d0b0a28caddcc10085f8b0"
+  },
+  {
+    "name": "post13-nfc-reorder-two-new-marks",
+    "input": {
+      "$str": "\u1715\u0c3c"
+    },
+    "profile": "semantic-content",
+    "note": "U+1715(ccc9,U15) + U+0C3C(ccc7,U15) reorder by ccc; both ccc=0 under a U13 DB",
+    "expected_canonical_bytes_b64": "IuCwvOGclSI=",
+    "expected_digest_hex": "394ddde97ebc5339036c5d92d0ad6b5aa9f2dbed44c6922877aaae4140993dcb"
+  },
+  {
+    "name": "astral-key-sort",
+    "input": {
+      "$obj": {
+        "\ud800\udc00": {
+          "$int": "2"
+        },
+        "\ue000": {
+          "$int": "1"
+        }
+      }
+    },
+    "profile": "semantic-content",
+    "expected_canonical_bytes_b64": "eyLugIAiOjEsIvCQgIAiOjJ9",
+    "expected_digest_hex": "24b019fe7d67f2b5ec74279c67263aa0de78fd19c8e787518002307ada7c4622"
+  },
+  {
+    "name": "non-ascii-raw",
+    "input": {
+      "$str": "\u65e5\u672c\u8a9e \ud83d\ude00"
+    },
+    "profile": "semantic-content",
+    "expected_canonical_bytes_b64": "IuaXpeacrOiqniDwn5iAIg==",
+    "expected_digest_hex": "a93f56f4a756d8af2fc075fa6f8673c31abbbd9566906ca6090ee9421ae45c84"
+  },
+  {
+    "name": "control-chars-escaped",
+    "input": {
+      "$str": "a\nb\tc\u0000d\u001f"
+    },
+    "profile": "semantic-content",
+    "expected_canonical_bytes_b64": "ImFcdTAwMGFiXHUwMDA5Y1x1MDAwMGRcdTAwMWYi",
+    "expected_digest_hex": "49313de37e110b1638932b0a8214995e26bf3c42c43605c224e793825d1e8b8a"
+  },
+  {
+    "name": "del-char-raw",
+    "input": {
+      "$str": "x\u007fy"
+    },
+    "profile": "semantic-content",
+    "expected_canonical_bytes_b64": "Inh/eSI=",
+    "expected_digest_hex": "9bf99aaaa234129a05d0c8f6d9ba0c680c97855f606c5f35d225fdd527eba1eb"
+  },
+  {
+    "name": "quote-backslash-escape",
+    "input": {
+      "$str": "a\"b\\c"
+    },
+    "profile": "semantic-content",
+    "expected_canonical_bytes_b64": "ImFcImJcXGMi",
+    "expected_digest_hex": "9483b07a2489491a81bb1f1e98e64c20d89663cf865a02e0a807b5fcbb4c5279"
+  },
+  {
+    "name": "boolean-value",
+    "input": {
+      "$obj": {
+        "t": {
+          "$bool": true
+        },
+        "f": {
+          "$bool": false
+        }
+      }
+    },
+    "profile": "semantic-content",
+    "expected_canonical_bytes_b64": "eyJmIjpmYWxzZSwidCI6dHJ1ZX0=",
+    "expected_digest_hex": "954521673d49dde6bc4349eaf19161eed2c75d9ca0ea047da4bf3305aaeb4e4d"
+  },
+  {
+    "name": "null-value",
+    "input": {
+      "$null": true
+    },
+    "profile": "semantic-content",
+    "expected_canonical_bytes_b64": "bnVsbA==",
+    "expected_digest_hex": "1e5f5472eca2793bfabef6fd7223e5954d2e7ba871d37bc956383cc313942a2b"
+  },
+  {
+    "name": "integer-basic",
+    "input": {
+      "$int": "42"
+    },
+    "profile": "semantic-content",
+    "expected_canonical_bytes_b64": "NDI=",
+    "expected_digest_hex": "a0b11ccc478e6b63f2eacce5d6842521a2e946a4c79d27b9fad8e89c33935051"
+  },
+  {
+    "name": "integer-negative-zero-large",
+    "input": {
+      "$arr": [
+        {
+          "$int": "0"
+        },
+        {
+          "$int": "-17"
+        },
+        {
+          "$int": "123456789012345678901234567890"
+        }
+      ]
+    },
+    "profile": "semantic-content",
+    "expected_canonical_bytes_b64": "WzAsLTE3LDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MF0=",
+    "expected_digest_hex": "22ac68c3c69bd9d05cee42b0269dda0dc09bde2e94abac2afcd62f6fc7a39d98"
+  },
+  {
+    "name": "nested-object-array",
+    "input": {
+      "$obj": {
+        "z": {
+          "$arr": [
+            {
+              "$obj": {
+                "k": {
+                  "$str": "v"
+                }
+              }
+            },
+            {
+              "$int": "1"
+            }
+          ]
+        },
+        "a": {
+          "$obj": {
+            "nested": {
+              "$arr": [
+                {
+                  "$bool": true
+                },
+                {
+                  "$null": true
+                }
+              ]
+            }
+          }
+        }
+      }
+    },
+    "profile": "semantic-content",
+    "expected_canonical_bytes_b64": "eyJhIjp7Im5lc3RlZCI6W3RydWUsbnVsbF19LCJ6IjpbeyJrIjoidiJ9LDFdfQ==",
+    "expected_digest_hex": "8940c0d9c1b13e213e9fedad845c7eb694b989997410bf5e35fab0bf0dcb0d84"
+  },
+  {
+    "name": "empty-object",
+    "input": {
+      "$obj": {}
+    },
+    "profile": "semantic-content",
+    "expected_canonical_bytes_b64": "e30=",
+    "expected_digest_hex": "5d38c49fdcd034178d76df1b9a51a48005fb10bee2b218d087ab8b7fe72083e7"
+  },
+  {
+    "name": "empty-array",
+    "input": {
+      "$arr": []
+    },
+    "profile": "semantic-content",
+    "expected_canonical_bytes_b64": "W10=",
+    "expected_digest_hex": "9ef34130fa41e1db7673200a3de5c96cab08b2c44c7b97431a175991c6737bdb"
+  },
+  {
+    "name": "profile-semantic-content",
+    "input": {
+      "$obj": {
+        "id": {
+          "$str": "x"
+        }
+      }
+    },
+    "profile": "semantic-content",
+    "expected_canonical_bytes_b64": "eyJpZCI6IngifQ==",
+    "expected_digest_hex": "6c7861bf3530a29bd8940352e87fd432a6864a5ce336909b4095db6eff7680e0"
+  },
+  {
+    "name": "profile-run",
+    "input": {
+      "$obj": {
+        "id": {
+          "$str": "x"
+        }
+      }
+    },
+    "profile": "run",
+    "expected_canonical_bytes_b64": "eyJpZCI6IngifQ==",
+    "expected_digest_hex": "a951ff2f451fd569c3d5be89854cdefd8285f066fe33cbb208a0594b1d4708f6"
+  },
+  {
+    "name": "profile-artifact-byte",
+    "input": {
+      "$obj": {
+        "id": {
+          "$str": "x"
+        }
+      }
+    },
+    "profile": "artifact-byte",
+    "expected_canonical_bytes_b64": "eyJpZCI6IngifQ==",
+    "expected_digest_hex": "32298e9799d2e2c3fe617270c4ac472d9393a99981328807b04ec5bfa5c3c01d"
+  },
+  {
+    "name": "profile-certificate",
+    "input": {
+      "$obj": {
+        "id": {
+          "$str": "x"
+        }
+      }
+    },
+    "profile": "certificate",
+    "expected_canonical_bytes_b64": "eyJpZCI6IngifQ==",
+    "expected_digest_hex": "ac35f581dba0eca0b85729c1d83d2a5e409d599ea1ba78f0597133314b1192e7"
+  },
+  {
+    "name": "digest-field-excluded",
+    "input": {
+      "$obj": {
+        "digest": {
+          "$str": "PLACEHOLDER-MUST-NOT-AFFECT-DIGEST"
+        },
+        "content": {
+          "$str": "real"
+        }
+      }
+    },
+    "profile": "semantic-content",
+    "expected_canonical_bytes_b64": "eyJjb250ZW50IjoicmVhbCIsImRpZ2VzdCI6IlBMQUNFSE9MREVSLU1VU1QtTk9ULUFGRkVDVC1ESUdFU1QifQ==",
+    "expected_digest_hex": "6db76bc39f64753eda300213f1e0fd634851406a8daeff52c28da8ba8dd1ebc0"
+  },
+  {
+    "name": "digest-field-excluded-baseline",
+    "input": {
+      "$obj": {
+        "content": {
+          "$str": "real"
+        }
+      }
+    },
+    "profile": "semantic-content",
+    "expected_canonical_bytes_b64": "eyJjb250ZW50IjoicmVhbCJ9",
+    "expected_digest_hex": "6db76bc39f64753eda300213f1e0fd634851406a8daeff52c28da8ba8dd1ebc0"
+  },
+  {
+    "name": "content-envelope-split",
+    "input": {
+      "$obj": {
+        "capability": {
+          "$str": "validate"
+        },
+        "version": {
+          "$int": "1"
+        }
+      }
+    },
+    "profile": "semantic-content",
+    "note": "digest must equal content-envelope-split-other; envelopes differ, content same",
+    "expected_canonical_bytes_b64": "eyJjYXBhYmlsaXR5IjoidmFsaWRhdGUiLCJ2ZXJzaW9uIjoxfQ==",
+    "expected_digest_hex": "0e16763fc6e32b3b49ffd7b86499fc416e8aa627a1de3be5bd03ac0dc2044c83"
+  },
+  {
+    "name": "content-envelope-split-other",
+    "input": {
+      "$obj": {
+        "capability": {
+          "$str": "validate"
+        },
+        "version": {
+          "$int": "1"
+        }
+      }
+    },
+    "profile": "semantic-content",
+    "note": "same content as content-envelope-split with a different (non-hashed) envelope",
+    "expected_canonical_bytes_b64": "eyJjYXBhYmlsaXR5IjoidmFsaWRhdGUiLCJ2ZXJzaW9uIjoxfQ==",
+    "expected_digest_hex": "0e16763fc6e32b3b49ffd7b86499fc416e8aa627a1de3be5bd03ac0dc2044c83"
+  },
+  {
+    "name": "reject-float",
+    "input": {
+      "$float": "1.0"
+    },
+    "profile": "semantic-content",
+    "expect_error": true
+  },
+  {
+    "name": "reject-nan",
+    "input": {
+      "$nan": true
+    },
+    "profile": "semantic-content",
+    "expect_error": true
+  },
+  {
+    "name": "reject-pos-inf",
+    "input": {
+      "$inf": 1
+    },
+    "profile": "semantic-content",
+    "expect_error": true
+  },
+  {
+    "name": "reject-neg-inf",
+    "input": {
+      "$inf": -1
+    },
+    "profile": "semantic-content",
+    "expect_error": true
+  },
+  {
+    "name": "reject-float-nested",
+    "input": {
+      "$obj": {
+        "price": {
+          "$float": "9.99"
+        }
+      }
+    },
+    "profile": "semantic-content",
+    "expect_error": true
+  },
+  {
+    "name": "reject-lone-surrogate",
+    "input": {
+      "$str": "\ud800"
+    },
+    "profile": "semantic-content",
+    "expect_error": true
+  }
+]

--- a/tests/test_boundary_determinism.py
+++ b/tests/test_boundary_determinism.py
@@ -242,27 +242,14 @@ def test_reordered_candidates_same_hash():
 #     run.root/source.path stored as str(root) (adapter.py:866,899,1151,1184);
 #     all survive canonicalization (serialization.py:79-84).
 # ---------------------------------------------------------------------------
-@pytest.mark.xfail(
-    strict=True,
-    reason="P0 bug-lock: node_id + semantic_text bake the absolute root path; turns green in P1",
-)
 def test_two_roots_same_parity_hash(tmp_path):
     """The SAME snapshot extracted under two DIFFERENT absolute checkout roots
     MUST produce identical PARITY bytes (stability / no false negatives).
 
-    CURRENTLY RED. Even after hand-stripping the known-volatile ``run.root`` /
-    ``source.path`` (see ``_strip_volatile``), the bytes still differ because
-    ``node_id`` is computed from the raw absolute caller path
-    (``compute_node_id(file_path=str(path), ...)`` via ``chunk_file``), and the
-    absolute path also leaks into ``metadata.semantic_text``. Two machines with
-    different checkout locations therefore hash the same code differently ->
-    false negative on a parity check.
-
-    Captured evidence (this tree): with roots ``/tmp/alpha_*`` vs
-    ``/tmp/beta_longer_*`` and identical ``m.py``:
-        node_id(rootA) != node_id(rootB)            # path baked into the hash
-        semantic_text contains the absolute "/tmp/alpha_.../m.py"
-        _hash(strip(irA)) != _hash(strip(irB))      # leak survives stripping
+    GREEN after P1. node_id/symbol_id/definition_id and semantic_text are all
+    keyed on the normalized repo-relative identity path (chunk_file now takes an
+    identity_path the adapter sets to the relative display_path; BUG-3), so two
+    checkout roots hash the same code identically.
     """
     root_a = tmp_path / "alpha"
     root_b = tmp_path / "beta_longer_name"
@@ -287,10 +274,6 @@ def test_two_roots_same_parity_hash(tmp_path):
 #     normalize_boundary_path (impact.py:11-12) only swaps backslashes -- it does
 #     NOT collapse ./, .., or redundant separators.
 # ---------------------------------------------------------------------------
-@pytest.mark.xfail(
-    strict=True,
-    reason="P0 bug-lock: normalize_boundary_path incomplete (BUG-4), cold vs incremental diverge; turns green in P1",
-)
 def test_cold_vs_incremental_same_bytes(tmp_path, monkeypatch):
     """``incremental=False`` and ``incremental=True`` on identical input MUST
     produce identical canonical bytes.
@@ -310,16 +293,14 @@ def test_cold_vs_incremental_same_bytes(tmp_path, monkeypatch):
         incr file path: "pkg/m.py"
         _hash(strip(cold)) != _hash(strip(incr))
 
-    Underlying BUG-4 (also asserted directly): ``normalize_boundary_path`` is
-    incomplete -- it only swaps backslashes:
-        normalize_boundary_path("./a/b.py") == "./a/b.py"   # './' NOT collapsed
-        normalize_boundary_path("a/../b.py") == "a/../b.py"  # '..' NOT collapsed
-        normalize_boundary_path("a//b.py")  == "a//b.py"     # '//' NOT collapsed
+    BUG-4 fixed: ``normalize_boundary_path`` is now total -- it POSIX-ifies and
+    collapses ``.`` / ``..`` / redundant separators, so cold and incremental
+    funnel every path through the same canonical form.
     """
-    # BUG-4: normalize_boundary_path is not total (drives the divergence below).
-    assert normalize_boundary_path("./a/b.py") == "./a/b.py"
-    assert normalize_boundary_path("a/../b.py") == "a/../b.py"
-    assert normalize_boundary_path("a//b.py") == "a//b.py"
+    # BUG-4: normalize_boundary_path is now total.
+    assert normalize_boundary_path("./a/b.py") == "a/b.py"
+    assert normalize_boundary_path("a/../b.py") == "b.py"
+    assert normalize_boundary_path("a//b.py") == "a/b.py"
 
     pkg = tmp_path / "pkg"
     pkg.mkdir()
@@ -359,25 +340,14 @@ def test_cold_vs_incremental_same_bytes(tmp_path, monkeypatch):
 #     file_path=str(path)); file_id/definition_id key on the relative display
 #     path -> within one IR the IDs are mutually inconsistent + non-portable.
 # ---------------------------------------------------------------------------
-@pytest.mark.xfail(
-    strict=True, reason="P0 bug-lock: node_id uses absolute path; turns green in P1"
-)
 def test_node_id_uses_relative_path(tmp_path):
     """A node's ``node_id`` MUST key on the repo-relative path (the same form as
     ``file_id``/``definition_id``), NOT on the absolute caller path.
 
-    CURRENTLY RED. ``chunk_file`` -> ``chunk_text`` computes ``node_id`` with
-    ``file_path=str(path)`` (an absolute path; core.py:983), while the Boundary
-    layer recomputes ``file_id``/``definition_id`` from the relative display
-    path. So ``node_id`` keys on the absolute checkout root: it differs across
-    machines and is mutually inconsistent with the other IDs in the same IR.
-
-    Proven exactly: the emitted ``node_id`` equals
-    ``compute_node_id(<ABS path>, ...)`` and does NOT equal
-    ``compute_node_id(<relative path>, ...)``.
-
-    Captured evidence (this tree): the absolute root also leaks verbatim into
-    the serialized node via ``metadata.semantic_text``.
+    GREEN after P1. The Boundary adapter passes the normalized repo-relative
+    display_path to ``chunk_file`` as ``identity_path`` (BUG-3), so the emitted
+    ``node_id`` equals ``compute_node_id(<relative path>, ...)`` and the absolute
+    checkout root no longer leaks into the serialized node (semantic_text).
     """
     from chunker.core import chunk_file
     from chunker.types import compute_node_id

--- a/tests/test_boundary_determinism.py
+++ b/tests/test_boundary_determinism.py
@@ -152,34 +152,24 @@ def _node_ir(metadata_list_field: str, items: list[str]) -> dict:
 # (1) RED -- false parity on order-significant string lists (BUG-1).
 #     Site: chunker/boundary/serialization.py:33-34 (_canonicalize_value).
 # ---------------------------------------------------------------------------
-@pytest.mark.xfail(
-    strict=True,
-    reason="P0 bug-lock: _canonicalize_value sorts all-string lists (false parity); turns green in P1",
-)
 def test_reordered_params_change_hash():
     """``params=["b","a"]`` and ``params=["a","b"]`` are DIFFERENT logical inputs
     and MUST produce different canonical bytes.
 
-    CURRENTLY RED. ``_canonicalize_value`` content-sniffs ("all items strings ->
-    sorted") so both orderings collapse to ``["a","b"]`` -> identical bytes ->
-    FALSE PARITY (a real parameter reorder becomes invisible to a hash check).
-
-    Captured evidence (this tree):
-        _canonicalize_value(["b","a"]) == ["a","b"]
-        IR(params=["a","b"]) bytes ... metadata == {"params":["a","b"]}
-        IR(params=["b","a"]) bytes ... metadata == {"params":["a","b"]}  # collapsed
+    GREEN after P1. ``_canonicalize_value`` no longer content-sniff-sorts
+    all-string lists (canon S4: array order is preserved ALWAYS), so a real
+    parameter reorder is now visible to a hash check (no false parity).
     """
-    # Direct proof of the offending branch (documents the exact mechanism):
-    assert _canonicalize_value(["b", "a"]) == ["a", "b"]  # the bug, isolated
+    # The content-sniff branch is gone: order is preserved verbatim.
+    assert _canonicalize_value(["b", "a"]) == ["b", "a"]
 
     forward = _node_ir("params", ["a", "b"])
     reordered = _node_ir("params", ["b", "a"])
 
-    # Sensitivity property: different order -> different bytes. FAILS today
-    # because both serialize identically (false parity).
+    # Sensitivity property: different order -> different bytes.
     assert _hash(forward) != _hash(reordered), (
-        "FALSE PARITY: reordered params hashed equal -- serialization.py:33-34 "
-        "sorts all-string lists, collapsing ['b','a'] to ['a','b']."
+        "reordered params must hash differently -- the serializer must preserve "
+        "list insertion order (canon S4)."
     )
 
 
@@ -187,37 +177,24 @@ def test_reordered_params_change_hash():
 # (2) RED -- false parity + silent de-dup on imports (BUG-1 via _stable_value).
 #     Site: chunker/boundary/adapter.py:95-96 (_stable_value).
 # ---------------------------------------------------------------------------
-@pytest.mark.xfail(
-    strict=True,
-    reason="P0 bug-lock: _stable_value sorts+dedups imports, destroying source order; turns green in P1",
-)
 def test_reordered_imports_change_hash():
     """A reordered ``metadata.imports`` list MUST change the canonical bytes.
 
-    CURRENTLY RED on two counts. ``_stable_value`` runs
-    ``sorted(dict.fromkeys(...))`` on all-string lists -- it both REORDERS and
-    DE-DUPLICATES -- and it is applied to ``metadata.{dependencies,exports,
-    imports}`` (adapter.py:160-168). So distinct import orderings collapse.
-
-    See the BUG-1b investigation in this module's docstring: ``imports`` is
-    order-significant at the extraction source but is sorted to mask it; P1 must
-    preserve source order.
-
-    Captured evidence (this tree):
-        _stable_value({"imports": ["b","a","b"]}) == {"imports": ["a","b"]}
-        _stable_value({"imports": ["a","b"]})     == {"imports": ["a","b"]}
-        # reorder lost AND the duplicate "b" silently dropped.
+    GREEN after P1. ``_stable_value`` no longer runs ``sorted(dict.fromkeys(...))``
+    on all-string lists -- it preserves list/tuple order verbatim (canon S4) and
+    no longer silently de-duplicates. ``imports`` is order-significant (BUG-1b):
+    a reorder is a different logical value and now hashes differently.
     """
-    # Direct proof of the offending branch, incl. the de-dup (the worse half):
-    assert _stable_value({"imports": ["b", "a", "b"]}) == {"imports": ["a", "b"]}
+    # The all-strings sort+dedup branch is gone: order AND duplicates preserved.
+    assert _stable_value({"imports": ["b", "a", "b"]}) == {"imports": ["b", "a", "b"]}
     assert _stable_value({"imports": ["a", "b"]}) == {"imports": ["a", "b"]}
 
     forward = _node_ir("imports", ["alpha", "beta"])
     reordered = _node_ir("imports", ["beta", "alpha"])
 
     assert _hash(forward) != _hash(reordered), (
-        "FALSE PARITY: reordered imports hashed equal -- adapter.py:95-96 "
-        "_stable_value sorts (and de-dups) all-string lists."
+        "reordered imports must hash differently -- _stable_value and the "
+        "serializer must preserve list order (canon S4; imports order-significant)."
     )
 
 

--- a/tests/test_boundary_parity_view.py
+++ b/tests/test_boundary_parity_view.py
@@ -1,0 +1,134 @@
+"""BUG-2: parity hash view excludes volatile fields and tolerates floats.
+
+These tests exercise the first-class parity API
+(``canonicalize_for_parity`` / ``canonicalize_for_parity_bytes`` /
+``parity_digest``) that ``spec`` and other canon consumers call instead of
+hand-stripping volatile fields. They are NOT covered by
+``test_boundary_determinism.py`` (which hand-strips and hashes
+``dumps_boundary_ir``), and crucially they exercise the FLOAT path that a default
+``extract_boundary_ir`` IR never produces.
+"""
+
+from __future__ import annotations
+
+import copy
+
+from chunker.boundary import (
+    canonicalize_for_parity,
+    canonicalize_for_parity_bytes,
+    parity_digest,
+)
+
+
+def _ir_with_float() -> dict:
+    """A minimal Boundary IR carrying floats (semantic-edge confidence and
+    run.options.semantic_min_confidence) -- canon rejects floats, so the parity
+    view MUST pre-represent them. Mirrors the test_boundary_determinism _node_ir
+    pattern but adds the float-bearing fields a real semantic IR has."""
+    return {
+        "schema_version": "1.0",
+        "source": {"kind": "file", "path": "/abs/checkout/m.py"},
+        "files": [],
+        "nodes": [
+            {
+                "id": "n1",
+                "identity": {"source": "node_id", "value": "n1"},
+                "node_id": "n1",
+                "definition_id": None,
+                "path": "m.py",
+                "span": {
+                    "start_line": 1,
+                    "end_line": 1,
+                    "byte_start": 0,
+                    "byte_end": 1,
+                },
+                "metadata": {},
+                "relationships": [],
+            }
+        ],
+        "edges": [
+            {
+                "id": "e1",
+                "source": "n1",
+                "target": "n2",
+                "type": "call",
+                "candidates": [],
+                "provenance": {"source": "semantic", "confidence": 0.9},
+            }
+        ],
+        "diagnostics": [],
+        "metrics": {"failure_buckets": {}},
+        "run": {
+            "tool": "treesitter-chunker",
+            "tool_version": "9.9.9",
+            "root": "/abs/checkout",
+            "created_at": "2026-06-20T00:00:00Z",
+            "canonical": True,
+            "options": {"semantic_min_confidence": 0.5},
+            "timings": {"total_ms": 12.345},
+        },
+    }
+
+
+def test_parity_view_tolerates_floats():
+    """canon rejects floats; the parity view must not raise on a float-bearing IR."""
+    ir = _ir_with_float()
+    # Must not raise -- floats are pre-represented as strings before canon.
+    raw = canonicalize_for_parity_bytes(ir)
+    assert isinstance(raw, bytes) and raw
+    assert isinstance(parity_digest(ir), str)
+    # The float survives as content (string form), not dropped.
+    view = canonicalize_for_parity(ir)
+    assert view["edges"][0]["provenance"]["confidence"] == repr(0.9)
+    assert view["run"]["options"]["semantic_min_confidence"] == repr(0.5)
+
+
+def test_parity_view_excludes_volatile_fields():
+    """Mutating any of the 5 volatile fields MUST NOT change the parity bytes.
+
+    This is the BUG-2 property; nothing else proves it. source.path,
+    run.{root,created_at,tool_version,timings} are excluded from hashed content.
+    """
+    base = _ir_with_float()
+    base_bytes = canonicalize_for_parity_bytes(base)
+
+    mutations = [
+        ("source.path", lambda ir: ir["source"].__setitem__("path", "/other/x.py")),
+        ("run.root", lambda ir: ir["run"].__setitem__("root", "/totally/different")),
+        ("run.created_at", lambda ir: ir["run"].__setitem__("created_at", "1999")),
+        ("run.tool_version", lambda ir: ir["run"].__setitem__("tool_version", "0.0.1")),
+        (
+            "run.timings",
+            lambda ir: ir["run"].__setitem__("timings", {"total_ms": 999.0}),
+        ),
+    ]
+    for name, mutate in mutations:
+        ir = copy.deepcopy(base)
+        mutate(ir)
+        assert canonicalize_for_parity_bytes(ir) == base_bytes, (
+            f"parity bytes changed when only the volatile field {name!r} changed; "
+            "it must be excluded from the hash view (BUG-2)."
+        )
+
+
+def test_parity_view_two_roots_identical():
+    """The same logical IR under two absolute roots hashes identically."""
+    ir_a = _ir_with_float()
+    ir_a["source"]["path"] = "/checkout/alpha/m.py"
+    ir_a["run"]["root"] = "/checkout/alpha"
+
+    ir_b = _ir_with_float()
+    ir_b["source"]["path"] = "/elsewhere/beta_longer/m.py"
+    ir_b["run"]["root"] = "/elsewhere/beta_longer"
+
+    assert canonicalize_for_parity_bytes(ir_a) == canonicalize_for_parity_bytes(ir_b)
+    assert parity_digest(ir_a) == parity_digest(ir_b)
+
+
+def test_parity_view_is_sensitive_to_content():
+    """A genuine content change MUST change the parity bytes (no false parity)."""
+    base = _ir_with_float()
+    changed = _ir_with_float()
+    changed["nodes"][0]["node_id"] = "DIFFERENT"
+    changed["nodes"][0]["id"] = "DIFFERENT"
+    assert canonicalize_for_parity_bytes(base) != canonicalize_for_parity_bytes(changed)

--- a/tests/test_canon_vectors.py
+++ b/tests/test_canon_vectors.py
@@ -50,9 +50,9 @@ def test_canon_vector_fidelity(vector: dict) -> None:
     profile = vector["profile"]
     expected_digest = vector["expected_digest_hex"]
     actual_digest = _canon.digest(value, profile)
-    assert actual_digest == expected_digest, (
-        f"canon digest divergence on vector {_vector_id(vector)!r}."
-    )
+    assert (
+        actual_digest == expected_digest
+    ), f"canon digest divergence on vector {_vector_id(vector)!r}."
 
 
 def test_unicode_db_is_pinned_16() -> None:

--- a/tests/test_canon_vectors.py
+++ b/tests/test_canon_vectors.py
@@ -1,0 +1,60 @@
+"""canon v1 vector-fidelity proof for the vendored serializer.
+
+``chunker/boundary/_canon.py`` is vendored verbatim from the spec ``canon`` v1
+reference impl (``canon/py/canon.py``). This module proves byte/digest fidelity
+by running canon's own conformance vector suite
+(``tests/fixtures/canon-vectors.json``, copied from ``canon/vectors``) through
+the vendored encoder and asserting the canonical bytes and digests match the
+values pinned in the vector file.
+
+If this test fails, the vendored copy has drifted from the spec contract and the
+Boundary IR can no longer be hashed soundly against other canon consumers.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from pathlib import Path
+
+import pytest
+
+from chunker.boundary import _canon
+
+_VECTORS_PATH = Path(__file__).parent / "fixtures" / "canon-vectors.json"
+_VECTORS = json.loads(_VECTORS_PATH.read_text(encoding="utf-8"))
+
+
+def _vector_id(vector: dict) -> str:
+    return str(vector.get("name", "<unnamed>"))
+
+
+@pytest.mark.parametrize("vector", _VECTORS, ids=[_vector_id(v) for v in _VECTORS])
+def test_canon_vector_fidelity(vector: dict) -> None:
+    """Every canon vector reproduces byte-for-byte through the vendored encoder."""
+    value = _canon.decode_input(vector["input"])
+
+    if vector.get("expect_error"):
+        # Reject cases (float / NaN / Infinity / lone surrogate).
+        with pytest.raises(_canon.CanonError):
+            _canon.canonical_bytes(value)
+        return
+
+    expected_bytes = base64.b64decode(vector["expected_canonical_bytes_b64"])
+    actual_bytes = _canon.canonical_bytes(value)
+    assert actual_bytes == expected_bytes, (
+        f"canon byte divergence on vector {_vector_id(vector)!r}: "
+        f"vendored copy of canon/py/canon.py no longer matches the spec contract."
+    )
+
+    profile = vector["profile"]
+    expected_digest = vector["expected_digest_hex"]
+    actual_digest = _canon.digest(value, profile)
+    assert actual_digest == expected_digest, (
+        f"canon digest divergence on vector {_vector_id(vector)!r}."
+    )
+
+
+def test_unicode_db_is_pinned_16() -> None:
+    """The vendored canon enforces the pinned Unicode 16.0 DB (fail-closed)."""
+    assert _canon._ACTUAL_UNICODE == "16.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1997,6 +1997,7 @@ dependencies = [
     { name = "tree-sitter" },
     { name = "tree-sitter-language-pack" },
     { name = "typer" },
+    { name = "unicodedata2" },
 ]
 
 [package.optional-dependencies]
@@ -2128,6 +2129,7 @@ requires-dist = [
     { name = "typer", specifier = ">=0.9.0" },
     { name = "types-pyyaml", marker = "extra == 'dev'" },
     { name = "types-setuptools", marker = "extra == 'dev'" },
+    { name = "unicodedata2", specifier = "==16.0.0" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'api'", specifier = ">=0.23.0" },
     { name = "wheel", marker = "extra == 'dev'" },
 ]
@@ -2205,6 +2207,32 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f8/b1/0c11f5058406b3af7609f121aaa6b609744687f1d158b3c3a5bf4cc94238/typing_inspection-0.4.1.tar.gz", hash = "sha256:6ae134cc0203c33377d43188d4064e9b357dba58cff3185f22924610e70a9d28", size = 75726, upload-time = "2025-05-21T18:55:23.885Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/17/69/cd203477f944c353c31bade965f880aa1061fd6bf05ded0726ca845b6ff7/typing_inspection-0.4.1-py3-none-any.whl", hash = "sha256:389055682238f53b04f7badcb49b989835495a96700ced5dab2d8feae4b26f51", size = 14552, upload-time = "2025-05-21T18:55:22.152Z" },
+]
+
+[[package]]
+name = "unicodedata2"
+version = "16.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/c6/f1aa23ed42259789c1c9bdeac219bfe72cc3046c3fc39ad3155705f81d9b/unicodedata2-16.0.0.tar.gz", hash = "sha256:05488d6592b59cd78b61ec37d38725416b2df62efafa6a0d63a631b27aa474fc", size = 672155, upload-time = "2025-01-11T11:59:45.548Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4e/28/e8c98a8cfe0338fd20768600aa87e460e863984dc03e07b57deeb2a990fa/unicodedata2-16.0.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:94f6cd7acc8177b3bba46cc605bcc586df1e7a8d0b1a59c0663ba6b8a2c65861", size = 963405, upload-time = "2025-01-11T11:58:12.183Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/bf/8b4caa3b3f4ea377cbebe3d05c07477647673b8816e28420e831b82feb1e/unicodedata2-16.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:95b36de92a05eadf74ea35130440e5748985f358ec9503eeaad7685a707d75f2", size = 489323, upload-time = "2025-01-11T11:58:14.604Z" },
+    { url = "https://files.pythonhosted.org/packages/07/bd/0d7aed7b6c9c53bcb3867d7a8ce7e43ba21a69584638cdfdb65129e8ef23/unicodedata2-16.0.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:38e5effb78231cbc790ac9417d07735b7a61686ecd0f5d7464efd6950944f9b3", size = 526269, upload-time = "2025-01-11T11:58:16.27Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/cd/cc73fca6314ef065140c621a2003720e9e62ac3a7a0c4e4c90d97b537b0d/unicodedata2-16.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b4bae57b986fd7a4cd0e8fed94abc2787e82d29d8f3cdd535a2cd5196b7a627a", size = 525373, upload-time = "2025-01-11T11:58:18.696Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/93/d63d8342433800cbb8f76bcd00b232bdc0cc4607329669ef19162f77e47e/unicodedata2-16.0.0-cp311-cp311-win32.whl", hash = "sha256:948355325d4e6f5ea7440760455f688c1c14c6ac49086321fbbc8d631392b5ce", size = 479186, upload-time = "2025-01-11T11:58:19.841Z" },
+    { url = "https://files.pythonhosted.org/packages/05/f1/4cd428aa54663ee904def7185d1a10f224076ca334a19cb0224211eeeab8/unicodedata2-16.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:6460fae678ad4216d6c316f065d51614b8480456d4b77a1d7649533a062db515", size = 479594, upload-time = "2025-01-11T11:58:22.203Z" },
+    { url = "https://files.pythonhosted.org/packages/57/9d/e7876176bd6cf6df66c81b812559118ac8bf59e321883c2ef1634130d2f4/unicodedata2-16.0.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:84ee7515900913105c3382ca7624cfa9e1199f64b80ee8cf9626b4e2786a2e09", size = 963513, upload-time = "2025-01-11T11:58:23.481Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/de/179828c64de38a9c44f626b1990c044640c79efdf672060c6579b2485ecb/unicodedata2-16.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:716f6522c6768f40a20c9e4559d68df9df84aca59a28335aa15a6ee3650a925e", size = 489355, upload-time = "2025-01-11T11:58:25.814Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/22/3714f83fa32862ddcc21b501ee7d4588f5eebaf32f4a3517e2fa6639a61e/unicodedata2-16.0.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c042613e639dfb21ed024bf39079fe560974083efc5f14ae6efe0241fdfe0275", size = 526783, upload-time = "2025-01-11T11:58:26.997Z" },
+    { url = "https://files.pythonhosted.org/packages/19/d4/560d59720db30f86795a2f1a67857c53f1c12757e44967ba91126062f099/unicodedata2-16.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:0c8902a6c194bbff878e0553e634c36267bb8a6a00ea2f9ce03f14feb5877ac5", size = 525841, upload-time = "2025-01-11T11:58:28.221Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/11/63fff30d6c97aef9444c28d22073970547aebe42138061dd30078c810e52/unicodedata2-16.0.0-cp312-cp312-win32.whl", hash = "sha256:676525702833b6b4fa1d2e8e5cd4f8e67e2b1c079eb2648042b259c4809e61aa", size = 479195, upload-time = "2025-01-11T11:58:29.938Z" },
+    { url = "https://files.pythonhosted.org/packages/83/d0/3329b81cacc6aa15e738d917c2416937c9d59d38810a9fb3b3d238761a12/unicodedata2-16.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:91c1f940bae6b39bc3dc9892ff0cc61de813f6d3b280775713219aaaab798210", size = 479564, upload-time = "2025-01-11T11:58:32.262Z" },
+    { url = "https://files.pythonhosted.org/packages/48/29/08bc9926673b02e43307c844b7df2ef06aa0ebe414c3ce3697b8fbd33eac/unicodedata2-16.0.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:67fe65dc2a7759469f98ab34315788f597259bfd2b50c47ab58f4c1337ecd95b", size = 963524, upload-time = "2025-01-11T11:58:34.804Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/fd/688c4219c53cfe4cf742c1418f2ec1d8fe1fb42846e7aba0652c2e7cf740/unicodedata2-16.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:82d88dbf353dd3b785249278d6c4b4f9bbe10f65f3b60619ad94e5d3012802ac", size = 489369, upload-time = "2025-01-11T11:58:36.041Z" },
+    { url = "https://files.pythonhosted.org/packages/26/ef/f96d6eaf9e63e630f84b452fff95d9aec7b9590bcdb94ca3bce8a3420405/unicodedata2-16.0.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64fc29fd4ea52946d6105bcf1fdb42198658de2ec0bd13b996390396454437a6", size = 526672, upload-time = "2025-01-11T11:58:40.288Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/34/0846e4c2e30ef8933f9bb7e430a78914ca58d8bc8f64d39caba89e13cdf1/unicodedata2-16.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1ca0a62c22dec4a76ee928cb4ca54166b986fbec150dc656890b3b2fc2fa2473", size = 525882, upload-time = "2025-01-11T11:58:42.697Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/07/a6543f9bb04177c571d00aa1544f6c1d86204c835e14219223f6f645de90/unicodedata2-16.0.0-cp313-cp313-win32.whl", hash = "sha256:5600f14cc73658a4d0d39c40484ae614045359021975d50ffb321aa4e3f91e06", size = 479188, upload-time = "2025-01-11T11:58:43.905Z" },
+    { url = "https://files.pythonhosted.org/packages/71/65/6017f3c06789fb128fe5cdad0946facf6eeba5174f15c69debf9b5e79873/unicodedata2-16.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:4c31fd7ac232a742e14afd03c77077eb0b4b48958ed7b2ceb304c030f221613d", size = 479563, upload-time = "2025-01-11T11:58:46.596Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adopts **canon v1** (the spec canonical-serialization contract S1) and fixes the Boundary-IR determinism bugs at the root, making the IR hash-safe and parity-safe. The 5 P0 `xfail(strict=True)` determinism tests are now normal **passing** tests (6/6 green, 0 xfail).

**Canon adoption method: VENDORED.** `canon/py/canon.py` is copied verbatim into `chunker/boundary/_canon.py` (source `sha256` pinned in its header; `unicodedata2==16.0.0` added). Byte/digest fidelity is proven by running canon's own conformance vector suite (36 vectors + the Unicode-16 pin) through the vendored encoder — `tests/test_canon_vectors.py`, 37 passing.

## What each bug fix did

- **BUG-1 (false parity on string lists).** Removed the "all-strings → `sorted`" content-sniff branch in both `serialization.py:_canonicalize_value` and `adapter.py:_stable_value` (incl. its `dict.fromkeys` de-dup). canon S4: array insertion order is preserved ALWAYS. The only authorized reorders are explicit field-keyed set-semantic sorts (`candidates`, node `relationships`, file `diagnostics`) alongside the existing top-level `files`/`nodes`/`edges`/`diagnostics` sorts.
- **BUG-1b (imports order).** `imports` are order-significant → source order preserved end-to-end (`_normalize_text_list(..., sort=False)`); `exports`/`dependencies` remain set-semantic (sorted at construction).
- **BUG-3/BUG-4 (path/identity portability).** `normalize_boundary_path` is now total (POSIX-ify, collapse `.`/`..`/redundant separators, idempotent). `chunk_file` gained an `identity_path` arg that decouples the read path from the identity path; the adapter passes the normalized repo-relative `display_path` on **both** cold and incremental paths, so `node_id`/`symbol_id`/`definition_id`/`chunk_id`/parent links/`semantic_text` all key on the same checkout-root-independent form. `_ensure_definition_id` always recomputes from that form.
- **BUG-2 (parity hash view).** New first-class API `canonicalize_for_parity()` / `canonicalize_for_parity_bytes()` / `parity_digest()` (exported from `chunker.boundary`). Pipeline: canonicalize → strip volatile fields (`source.path`, `run.{root,created_at,tool_version,timings}`) → pre-represent floats as strings (canon S6 rejects all floats; generic, not field-enumerated) → route through vendored canon for cross-tool byte-identity. Full fields stay in the human-readable document.

## Determinism tests — all green

`tests/test_boundary_determinism.py`: **6 passed, 0 xfailed, 0 failed.** The 5 P0 xfail markers were removed as each bug was fixed (and the inline bug-proof asserts updated to the corrected behavior); the `test_reordered_candidates_same_hash` GREEN guard still passes. New `tests/test_boundary_parity_view.py` (4 passing) proves the BUG-2 property on a float-bearing IR.

Lint clean (ruff + black; vendored `_canon.py` is `force-exclude`d from black to stay byte-faithful). Boundary subset green (160 passed; the only remaining ERRORs are the pre-existing `@classmethod`-fixture collection artifact unrelated to this branch). The 4 boundary-IR golden snapshots were regenerated to reflect the corrected IR.

## ⚠️ BREAKING — boundary-IR hashes/ids change; consumers must re-index

`node_id`, `symbol_id`, `definition_id`, `chunk_id` **values** and canonical **bytes** change (now repo-relative, content-sniff sort removed, imports unsorted). Every consumer storing these (Code-Index-MCP, codegraph-de, greenfield) must re-extract and re-index after upgrade.

**Release deferred — no version bump, no tag/publish in this PR** (the MAJOR wheel is a later coordinated phase).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G6NtqFtBPRyge7mZuLyrbs