### PR TITLE
P3: release 3.0.0 — MAJOR (breaking boundary-IR determinism fix; schema_version 2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,69 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.0] - 2026-06-21
+
+MAJOR — breaking Boundary-IR determinism fix. This release closes the
+treesitter-chunker P0→P3 work-stream that makes the `chunker.boundary` Boundary
+IR deterministic and parity-safe. Both version signals move together because ID
+*values* and canonical *bytes* both change — this is a re-index, not a rewrite.
+
+### 💥 BREAKING
+
+- **Boundary-IR determinism fixes (canon v1 adoption).** `node_id`,
+  `symbol_id`, `definition_id`, and `chunk_id` **VALUES** and the canonical
+  **BYTES** all change. Pre-3.0.0 IDs and hashes are **NOT comparable** to
+  `>=3.0.0` ones. Any consumer that stores these IDs or canonical/parity hashes
+  (Code-Index-MCP, codegraph-de, greenfield, spec) **MUST RE-EXTRACT and
+  RE-INDEX** after upgrading. There is no in-place migration of stored IDs.
+- **`schema_version` bumped `1.0` → `2.0`** (and the semantic schema
+  `1.1` → `2.1`) so consumers detect the break at the document level. The
+  published IR JSON Schema now rejects `1.x` documents and a `1.x` schema rejects
+  `2.x` documents — cross-version hash comparison is structurally refused.
+- **Public API signatures are UNCHANGED.** The `chunker.boundary` import surface
+  (`extract_boundary_ir`, `dumps_boundary_ir`, `canonicalize_boundary_ir`,
+  `canonicalize_for_parity` / `canonicalize_for_parity_bytes` / `parity_digest`,
+  `select_node_identity`, the published JSON Schema + loader) is stable;
+  `BOUNDARY_PUBLIC_API_VERSION` stays `1.0`. Consumers need a **re-index, not a
+  rewrite** — the break is in the emitted ID/byte content, not the call surface.
+
+### ✨ What landed (P1 + P2 + P3)
+
+- **P1 — canon v1 parity core.** Killed the content-sniff "all-strings → sort"
+  branch (lists now preserve insertion order; only schema-authorized set lists
+  sort at construction); total path normalization unified across cold and
+  incremental extraction; absolute paths stripped from hashed material; all IDs
+  recomputed from a single repo-relative POSIX form; first-class parity-hash view
+  (`canonicalize_for_parity*` / `parity_digest`) excluding volatile fields
+  (`run.root`, `source.path`, `created_at`, `tool_version`, `run.timings`).
+- **P2 — frozen contract + pinned surface.** `definition_id` (and
+  `node_id`/`file_id`/`symbol_id`) documented as **Tier-2 occurrence
+  fingerprints, NOT refactor-stable identities** (`spec` owns rename/move
+  continuity); machine-readable IR JSON Schema published and CI-validated against
+  real emitter output; narrow public surface carved and pinned
+  (`BOUNDARY_PUBLIC_API_VERSION = "1.0"`).
+- **P3 — MAJOR release.** Package `2.2.24` → `3.0.0`; `schema_version`
+  `1.0` → `2.0` / semantic `1.1` → `2.1`; golden snapshots regenerated;
+  migration notes (this entry).
+- **Toolchain pins.** `tree_sitter` 0.24 / `tree-sitter-language-pack` 0.9 ABI
+  pairing pinned; `ruff` and `black` locked in CI for reproducible lint/format.
+
+### 🧭 Migration
+
+1. Upgrade the pin to `treesitter-chunker==3.0.0`.
+2. Re-extract every repository you index and re-index the new IDs/hashes; do not
+   compare any stored `<3.0.0` ID or hash to a `>=3.0.0` one.
+3. Validate emitted documents against the published `2.x` JSON Schema
+   (`load_boundary_ir_schema()`); a `1.x` document will fail validation, which is
+   the intended cross-version guard.
+
+### 📝 Deferred
+
+- An explicitly emitted `canonicalization_version` field (so a consumer could
+  refuse cross-revision hash comparison via a dedicated field rather than via
+  `schema_version`) is an open question and is **NOT** added in 3.0.0. The
+  `schema_version` `1.x`/`2.x` split already enforces the break this release.
+
 ## [2.2.24] - 2026-05-01
 
 ### ✨ Features

--- a/chunker/boundary/__init__.py
+++ b/chunker/boundary/__init__.py
@@ -28,8 +28,8 @@ Identity
     - ``select_node_identity`` -- Tier-2 node-identity precedence selection.
 
 Schema + versions
-    - ``BOUNDARY_IR_SCHEMA_VERSION`` (document schema_version, "1.0").
-    - ``BOUNDARY_IR_SEMANTIC_SCHEMA_VERSION`` ("1.1").
+    - ``BOUNDARY_IR_SCHEMA_VERSION`` (document schema_version, "2.0").
+    - ``BOUNDARY_IR_SEMANTIC_SCHEMA_VERSION`` ("2.1").
     - ``BOUNDARY_IR_SCHEMA_PATH`` / ``load_boundary_ir_schema`` -- the published
       machine-readable JSON Schema (``boundary_ir.schema.json``, packaged in the
       wheel) so consumers can validate documents and detect drift.

--- a/chunker/boundary/boundary_ir.schema.json
+++ b/chunker/boundary/boundary_ir.schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/ViperJuice/treesitter-chunker/schemas/boundary-ir/1.0.json",
+  "$id": "https://github.com/ViperJuice/treesitter-chunker/schemas/boundary-ir/2.0.json",
   "title": "Boundary IR",
-  "description": "Machine-readable contract for the treesitter-chunker Boundary IR document (schema_version 1.0). Authored against, and CI-validated against, real extract_boundary_ir(..., canonical=True) output (the committed golden snapshots plus a freshly emitted sample). The document-level schema_version is '1.0' for the syntax-only baseline; semantic enrichment uses the additive '1.1' semantic schema version and adds the optional fields marked below. Identity fields (definition_id, node_id, file_id, symbol_id, identity.value) are Tier-2 occurrence fingerprints, not refactor-stable identities -- see docs/agent-interface-readiness.md.",
+  "description": "Machine-readable contract for the treesitter-chunker Boundary IR document (schema_version 2.0). Authored against, and CI-validated against, real extract_boundary_ir(..., canonical=True) output (the committed golden snapshots plus a freshly emitted sample). The document-level schema_version is '2.0' for the syntax-only baseline; semantic enrichment uses the additive '2.1' semantic schema version and adds the optional fields marked below. The 2.x schema_version line is a hard break from 1.x: the canon v1 boundary-IR determinism fix (treesitter-chunker >=3.0.0) changed both ID values and canonical bytes, so a 1.0/1.1 document does NOT validate here and a 2.0/2.1 document does NOT validate against the 1.x schema -- consumers must re-extract and re-index. Identity fields (definition_id, node_id, file_id, symbol_id, identity.value) are Tier-2 occurrence fingerprints, not refactor-stable identities -- see docs/agent-interface-readiness.md.",
   "type": "object",
   "required": [
     "schema_version",
@@ -18,7 +18,8 @@
   "properties": {
     "schema_version": {
       "type": "string",
-      "description": "Boundary IR document schema version. '1.0' for the syntax-only baseline."
+      "enum": ["2.0", "2.1"],
+      "description": "Boundary IR document schema version. '2.0' for the syntax-only baseline; '2.1' for semantic enrichment. 1.x documents (pre-3.0.0 canon) are rejected by this 2.x schema -- consumers must re-extract and re-index."
     },
     "source": {
       "type": "object",

--- a/chunker/boundary/types.py
+++ b/chunker/boundary/types.py
@@ -15,8 +15,8 @@ BoundaryIR: TypeAlias = dict[str, Any]
 BoundaryRecord: TypeAlias = dict[str, Any]
 SemanticEdgeSource: TypeAlias = Literal["semantic"]
 
-BOUNDARY_IR_SCHEMA_VERSION = "1.0"
-BOUNDARY_IR_SEMANTIC_SCHEMA_VERSION = "1.1"
+BOUNDARY_IR_SCHEMA_VERSION = "2.0"
+BOUNDARY_IR_SEMANTIC_SCHEMA_VERSION = "2.1"
 SEMANTIC_RESOLVER_API_VERSION = "1.0"
 BOUNDARY_CACHE_VERSION = "1"
 BOUNDARY_CACHE_KEY_PREFIX = "boundary:v1:"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name            = "treesitter-chunker"
-version = "2.2.24"
+version = "3.0.0"
 description     = "Semantic code chunker using Tree-sitter for intelligent code analysis"
 readme          = "README.md"
 requires-python = ">=3.11"

--- a/tests/fixtures/boundary_ir/golden/go.json
+++ b/tests/fixtures/boundary_ir/golden/go.json
@@ -650,7 +650,7 @@
     "tool": "treesitter-chunker",
     "tool_version": "<tool-version>"
   },
-  "schema_version": "1.0",
+  "schema_version": "2.0",
   "source": {
     "kind": "repository",
     "path": "tests/fixtures/boundary_ir/repos/go"

--- a/tests/fixtures/boundary_ir/golden/javascript.json
+++ b/tests/fixtures/boundary_ir/golden/javascript.json
@@ -1009,7 +1009,7 @@
     "tool": "treesitter-chunker",
     "tool_version": "<tool-version>"
   },
-  "schema_version": "1.0",
+  "schema_version": "2.0",
   "source": {
     "kind": "repository",
     "path": "tests/fixtures/boundary_ir/repos/javascript"

--- a/tests/fixtures/boundary_ir/golden/python.json
+++ b/tests/fixtures/boundary_ir/golden/python.json
@@ -874,7 +874,7 @@
     "tool": "treesitter-chunker",
     "tool_version": "<tool-version>"
   },
-  "schema_version": "1.0",
+  "schema_version": "2.0",
   "source": {
     "kind": "repository",
     "path": "tests/fixtures/boundary_ir/repos/python"

--- a/tests/fixtures/boundary_ir/golden/typescript.json
+++ b/tests/fixtures/boundary_ir/golden/typescript.json
@@ -1427,7 +1427,7 @@
     "tool": "treesitter-chunker",
     "tool_version": "<tool-version>"
   },
-  "schema_version": "1.0",
+  "schema_version": "2.0",
   "source": {
     "kind": "repository",
     "path": "tests/fixtures/boundary_ir/repos/typescript"

--- a/tests/test_boundary_ir_adapter.py
+++ b/tests/test_boundary_ir_adapter.py
@@ -31,7 +31,7 @@ def test_extract_boundary_ir_python_repo_is_deterministic(tmp_path: Path):
         "schema_version",
         "source",
     ]
-    assert first["schema_version"] == "1.0"
+    assert first["schema_version"] == "2.0"
     assert first["files"][0]["path"] == "service.py"
     assert first["metrics"]["files_total"] == 1
     assert first["metrics"]["nodes_total"] >= 2
@@ -47,7 +47,7 @@ def test_extract_boundary_ir_top_level_export_matches_boundary_module(tmp_path: 
     public = extract_boundary_ir_public(tmp_path, "python")
 
     assert public == direct
-    assert public["schema_version"] == "1.0"
+    assert public["schema_version"] == "2.0"
 
 
 def test_extract_boundary_ir_single_file_uses_file_source_kind(tmp_path: Path):

--- a/tests/test_boundary_ir_cli.py
+++ b/tests/test_boundary_ir_cli.py
@@ -17,7 +17,7 @@ def test_boundary_command_writes_json_to_stdout(tmp_path: Path):
 
     assert result.exit_code == 0
     data = json.loads(result.output)
-    assert data["schema_version"] == "1.0"
+    assert data["schema_version"] == "2.0"
     assert data["run"]["created_at"] is None
     assert data["run"]["options"]["resolution_mode"] == "strict"
     assert "Boundary IR written" not in result.output
@@ -57,7 +57,7 @@ def test_boundary_command_writes_output_file(tmp_path: Path):
     assert result.exit_code == 0
     assert "Boundary IR written" in result.output
     data = json.loads(output.read_text(encoding="utf-8"))
-    assert data["schema_version"] == "1.0"
+    assert data["schema_version"] == "2.0"
 
 
 def test_boundary_command_quiet_file_output_suppresses_human_text(tmp_path: Path):
@@ -80,7 +80,7 @@ def test_boundary_command_quiet_file_output_suppresses_human_text(tmp_path: Path
 
     assert result.exit_code == 0
     assert result.output == ""
-    assert json.loads(output.read_text(encoding="utf-8"))["schema_version"] == "1.0"
+    assert json.loads(output.read_text(encoding="utf-8"))["schema_version"] == "2.0"
 
 
 def test_existing_chunk_json_command_still_works(tmp_path: Path):

--- a/tests/test_boundary_ir_cli_incremental.py
+++ b/tests/test_boundary_ir_cli_incremental.py
@@ -40,7 +40,7 @@ def test_boundary_cli_incremental_stdout_is_parseable_and_stable(tmp_path: Path)
 
     assert cold.exit_code == 0
     assert warm.exit_code == 0
-    assert json.loads(cold.stdout)["schema_version"] == "1.0"
+    assert json.loads(cold.stdout)["schema_version"] == "2.0"
     assert cold.stdout == warm.stdout
 
 

--- a/tests/test_boundary_ir_cli_observability.py
+++ b/tests/test_boundary_ir_cli_observability.py
@@ -37,7 +37,7 @@ def test_boundary_cli_stdout_json_is_not_polluted_by_default(tmp_path: Path):
     result = runner.invoke(app, ["boundary", str(source), "--lang", "python"])
 
     assert result.exit_code == 0
-    assert json.loads(result.stdout)["schema_version"] == "1.0"
+    assert json.loads(result.stdout)["schema_version"] == "2.0"
     assert "Boundary IR summary" not in result.stdout
 
 
@@ -51,7 +51,7 @@ def test_boundary_cli_summary_uses_stderr_without_polluting_stdout(tmp_path: Pat
     )
 
     assert result.exit_code == 0
-    assert json.loads(result.stdout)["schema_version"] == "1.0"
+    assert json.loads(result.stdout)["schema_version"] == "2.0"
     assert "Boundary IR summary" in result.stderr
 
 

--- a/tests/test_boundary_ir_identity.py
+++ b/tests/test_boundary_ir_identity.py
@@ -22,7 +22,7 @@ def _chunk(**overrides):
 
 
 def test_schema_version_is_frozen():
-    assert BOUNDARY_IR_SCHEMA_VERSION == "1.0"
+    assert BOUNDARY_IR_SCHEMA_VERSION == "2.0"
 
 
 def test_select_node_identity_prefers_definition_id():

--- a/tests/test_boundary_ir_semantic_contract.py
+++ b/tests/test_boundary_ir_semantic_contract.py
@@ -14,7 +14,7 @@ from chunker.boundary.types import DIAGNOSTIC_STAGES
 
 def test_semantic_constants_are_frozen_and_exported():
     assert SEMANTIC_RESOLVER_API_VERSION == "1.0"
-    assert BOUNDARY_IR_SEMANTIC_SCHEMA_VERSION == "1.1"
+    assert BOUNDARY_IR_SEMANTIC_SCHEMA_VERSION == "2.1"
     assert SEMANTIC_EDGE_SOURCES == ("semantic",)
     assert "semantic" in DIAGNOSTIC_STAGES
 

--- a/uv.lock
+++ b/uv.lock
@@ -2164,7 +2164,7 @@ wheels = [
 
 [[package]]
 name = "treesitter-chunker"
-version = "2.2.24"
+version = "3.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "chardet" },


### PR DESCRIPTION
## P3 — MAJOR release 3.0.0 (breaking Boundary-IR determinism fix)

This is the **breaking MAJOR** that closes the treesitter-chunker P0→P3 work-stream. Both version signals move **together** because ID *values* and canonical *bytes* both change — **consumers re-index, not rewrite**.

### What changed
- **`pyproject.toml`**: `2.2.24` → `3.0.0` (`uv.lock` follows, version-only).
- **`chunker/boundary/types.py`**: `BOUNDARY_IR_SCHEMA_VERSION` `1.0` → `2.0`; `BOUNDARY_IR_SEMANTIC_SCHEMA_VERSION` `1.1` → `2.1` (semantic stays one minor ahead; `SEMANTIC_RESOLVER_API_VERSION` unchanged).
- **`chunker/boundary/boundary_ir.schema.json`**: `schema_version` property now `enum: ["2.0", "2.1"]` so a `>=3.0.0` document (schema_version `2.0`/`2.1`) **validates** and a `1.0`/`1.1` document **does NOT**; `$id` and descriptions bumped to `2.0`/`2.1`. (`enum`, not `const`, so semantic-enriched `2.1` docs still validate — the emitter flips to the semantic version when resolvers are passed.)
- **`chunker/boundary/__init__.py`**: docstring schema_version refs `1.0`→`2.0` / `1.1`→`2.1`. **`BOUNDARY_PUBLIC_API_VERSION` stays `1.0`** — the import surface is unchanged.
- **Golden snapshots** regenerated from the live emitter; diff is `schema_version` `1.0`→`2.0` only across all four langs (no byte drift — confirms a pure version bump).
- **Test assertions** on emitter output updated `1.0`→`2.0` / `1.1`→`2.1`.
- **`CHANGELOG.md`**: `## 3.0.0` entry with the migration notes below + P1+P2+P3 summary.

### Migration (BREAKING)
`node_id` / `symbol_id` / `definition_id` / `chunk_id` **VALUES** and canonical **BYTES** all change (canon v1 adoption). Pre-3.0.0 IDs/hashes are **NOT comparable** to `>=3.0.0`. Consumers storing these (Code-Index-MCP, codegraph-de, greenfield, spec) **MUST RE-EXTRACT + RE-INDEX**. Public API signatures are **unchanged** — re-index, not rewrite. `schema_version` `1.0`→`2.0` so consumers detect the break at the document level (1.x docs are refused by the 2.x schema and vice-versa).

Also rolled up: tree_sitter 0.24 / language-pack 0.9 ABI pin; ruff/black locked in CI; IR JSON Schema published + public surface pinned (`BOUNDARY_PUBLIC_API_VERSION = "1.0"`).

### Deferred
No new emitted `canonicalization_version` field this release (open question). The `schema_version` `1.x`/`2.x` split already enforces the break.

### Verification (local; PR CI is authority)
- `tests/test_boundary_ir_schema.py` + `tests/test_boundary_determinism.py`: green with `2.0`.
- CI smoke gate (`scripts/run_ci_smoke.py`): 161 passed.
- Boundary-IR suites (schema/determinism/golden/parity/cli/adapter/identity/semantic/serialization): 74 passed.
- Sanity: emitting an IR produces `schema_version "2.0"` and validates; a `1.0` doc is rejected; a `2.1` semantic doc validates.
- Lint clean (uv-locked ruff + black on touched files).

> No tag / no publish / no release.yml in this PR — the irreversible publish is the lead's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G6NtqFtBPRyge7mZuLyrbs