### PR TITLE
test-hygiene: fix classmethod-over-fixture collection bug across the suite

### DIFF
--- a/tests/integration/test_coordinator.py
+++ b/tests/integration/test_coordinator.py
@@ -19,9 +19,8 @@ from tests.integration.coordinator import (
 class TestIntegrationCoordinator:
     """Test the IntegrationCoordinator class."""
 
-    @classmethod
     @pytest.fixture
-    def coordinator(cls, tmp_path):
+    def coordinator(self, tmp_path):
         """Create a coordinator instance."""
         base_path = tmp_path / "worktrees"
         main_repo = tmp_path / "main"

--- a/tests/phase13_debug_tools_integration.py
+++ b/tests/phase13_debug_tools_integration.py
@@ -14,9 +14,8 @@ from chunker.debug.tools import DebugVisualization
 class TestDebugToolsIntegration:
     """Test debug tools integrate with core chunker"""
 
-    @classmethod
     @pytest.fixture
-    def test_file(cls):
+    def test_file(self):
         """Create a test Python file"""
         content = """def hello():
     print("Hello, World!")

--- a/tests/test_adaptive_chunker.py
+++ b/tests/test_adaptive_chunker.py
@@ -9,9 +9,8 @@ from chunker.strategies.adaptive import AdaptiveChunker, AdaptiveMetrics
 class TestAdaptiveChunker:
     """Test suite for AdaptiveChunker."""
 
-    @classmethod
     @pytest.fixture
-    def adaptive_chunker(cls):
+    def adaptive_chunker(self):
         """Create an adaptive chunker instance."""
         return AdaptiveChunker()
 

--- a/tests/test_composite_chunker.py
+++ b/tests/test_composite_chunker.py
@@ -15,9 +15,8 @@ from chunker.types import CodeChunk
 class TestCompositeChunker:
     """Test suite for CompositeChunker."""
 
-    @classmethod
     @pytest.fixture
-    def composite_chunker(cls):
+    def composite_chunker(self):
         """Create a composite chunker instance."""
         return CompositeChunker()
 

--- a/tests/test_debug_contract_impl.py
+++ b/tests/test_debug_contract_impl.py
@@ -16,15 +16,13 @@ from chunker.debug.visualization_impl import DebugVisualizationImpl
 class TestDebugVisualizationImpl:
     """Test DebugVisualizationImpl contract implementation"""
 
-    @classmethod
     @pytest.fixture
-    def impl(cls):
+    def impl(self):
         """Create implementation instance"""
         return DebugVisualizationImpl()
 
-    @classmethod
     @pytest.fixture
-    def sample_file(cls):
+    def sample_file(self):
         """Create a sample Python file"""
         content = """def hello():
     print("Hello, World!")
@@ -112,15 +110,13 @@ class Example:
 class TestChunkComparisonImpl:
     """Test ChunkComparisonImpl contract implementation"""
 
-    @classmethod
     @pytest.fixture
-    def impl(cls):
+    def impl(self):
         """Create implementation instance"""
         return ChunkComparisonImpl()
 
-    @classmethod
     @pytest.fixture
-    def sample_file(cls):
+    def sample_file(self):
         """Create a sample Python file"""
         content = """def process_data(data):
     result = [item * 2 for item in data if item > 0]    return result

--- a/tests/test_debug_tools_integration.py
+++ b/tests/test_debug_tools_integration.py
@@ -15,9 +15,8 @@ from chunker.debug.tools import ChunkComparison, DebugVisualization
 class TestDebugToolsIntegration:
     """Test debug tools integrate with core chunker"""
 
-    @classmethod
     @pytest.fixture
-    def sample_python_file(cls):
+    def sample_python_file(self):
         """Create a sample Python file for testing"""
         content = """def hello(name):
     ""\"Say hello""\"

--- a/tests/test_grammar_discovery.py
+++ b/tests/test_grammar_discovery.py
@@ -15,9 +15,8 @@ from chunker.grammar.discovery import GrammarDiscoveryService
 class TestGrammarDiscoveryService:
     """Test the real GrammarDiscoveryService implementation"""
 
-    @classmethod
     @pytest.fixture
-    def discovery_service(cls):
+    def discovery_service(self):
         """Create a discovery service with a temporary cache directory"""
         with tempfile.TemporaryDirectory() as tmpdir:
             service = GrammarDiscoveryService()

--- a/tests/test_graphml_exporter.py
+++ b/tests/test_graphml_exporter.py
@@ -13,9 +13,8 @@ from chunker.types import CodeChunk
 class TestGraphMLExporter:
     """Test GraphML export functionality."""
 
-    @classmethod
     @pytest.fixture
-    def sample_chunk(cls):
+    def sample_chunk(self):
         """Create a sample code chunk."""
         return CodeChunk(
             file_path="test.py",
@@ -31,9 +30,8 @@ class TestGraphMLExporter:
             metadata={"name": "test", "chunk_type": "function"},
         )
 
-    @classmethod
     @pytest.fixture
-    def exporter(cls):
+    def exporter(self):
         """Create a GraphMLExporter instance."""
         return GraphMLExporter()
 

--- a/tests/test_hierarchical_chunker.py
+++ b/tests/test_hierarchical_chunker.py
@@ -9,9 +9,8 @@ from chunker.strategies.hierarchical import HierarchicalChunker
 class TestHierarchicalChunker:
     """Test suite for HierarchicalChunker."""
 
-    @classmethod
     @pytest.fixture
-    def hierarchical_chunker(cls):
+    def hierarchical_chunker(self):
         """Create a hierarchical chunker instance."""
         return HierarchicalChunker()
 

--- a/tests/test_incremental_integration.py
+++ b/tests/test_incremental_integration.py
@@ -20,9 +20,8 @@ from chunker.types import CodeChunk
 class TestIncrementalIntegration:
     """Integration tests for incremental processing."""
 
-    @classmethod
     @pytest.fixture
-    def temp_project(cls):
+    def temp_project(self):
         """Create a temporary project structure."""
         temp_dir = tempfile.mkdtemp()
         src_dir = Path(temp_dir) / "src"

--- a/tests/test_language_config.py
+++ b/tests/test_language_config.py
@@ -306,9 +306,8 @@ class TestConfigValidation:
 class TestLanguageConfigRegistry:
     """Test the language configuration registry."""
 
-    @classmethod
     @pytest.fixture
-    def registry(cls):
+    def registry(self):
         """Create a fresh registry for each test."""
         reg = LanguageConfigRegistry(enable_lazy_loading=False)
         yield reg

--- a/tests/test_log_processor.py
+++ b/tests/test_log_processor.py
@@ -11,9 +11,8 @@ from chunker.processors.logs import LogProcessor
 class TestLogProcessor:
     """Test suite for LogProcessor."""
 
-    @classmethod
     @pytest.fixture
-    def processor(cls):
+    def processor(self):
         """Create a default LogProcessor instance."""
         return LogProcessor()
 

--- a/tests/test_markdown_processor.py
+++ b/tests/test_markdown_processor.py
@@ -18,15 +18,13 @@ from chunker.types import CodeChunk
 class TestMarkdownProcessor:
     """Test suite for MarkdownProcessor."""
 
-    @classmethod
     @pytest.fixture
-    def processor(cls):
+    def processor(self):
         """Create a default processor instance."""
         return MarkdownProcessor()
 
-    @classmethod
     @pytest.fixture
-    def custom_processor(cls):
+    def custom_processor(self):
         """Create a processor with custom configuration."""
         config = ProcessorConfig(
             max_chunk_size=500,

--- a/tests/test_metadata_extraction.py
+++ b/tests/test_metadata_extraction.py
@@ -78,14 +78,12 @@ class TestMetadataExtractorFactory:
 class TestPythonMetadataExtraction:
     """Test Python-specific metadata extraction."""
 
-    @classmethod
     @pytest.fixture
-    def extractor(cls):
+    def extractor(self):
         return PythonMetadataExtractor()
 
-    @classmethod
     @pytest.fixture
-    def analyzer(cls):
+    def analyzer(self):
         return PythonComplexityAnalyzer()
 
     @staticmethod
@@ -299,14 +297,12 @@ def example():
 class TestJavaScriptMetadataExtraction:
     """Test JavaScript-specific metadata extraction."""
 
-    @classmethod
     @pytest.fixture
-    def extractor(cls):
+    def extractor(self):
         return JavaScriptMetadataExtractor()
 
-    @classmethod
     @pytest.fixture
-    def analyzer(cls):
+    def analyzer(self):
         return JavaScriptComplexityAnalyzer()
 
     @staticmethod
@@ -430,9 +426,8 @@ function processItems(items) {
 class TestTypeScriptMetadataExtraction:
     """Test TypeScript-specific metadata extraction."""
 
-    @classmethod
     @pytest.fixture
-    def extractor(cls):
+    def extractor(self):
         return TypeScriptMetadataExtractor()
 
     @staticmethod

--- a/tests/test_nasm_language.py
+++ b/tests/test_nasm_language.py
@@ -11,9 +11,8 @@ from chunker.parser import get_parser
 class TestNASMPlugin:
     """Test suite for NASM language plugin."""
 
-    @classmethod
     @pytest.fixture
-    def plugin(cls):
+    def plugin(self):
         """Create a NASM plugin instance."""
         return NASMPlugin()
 

--- a/tests/test_optimization.py
+++ b/tests/test_optimization.py
@@ -17,9 +17,8 @@ from chunker import (
 class TestChunkOptimizer:
     """Test suite for ChunkOptimizer."""
 
-    @classmethod
     @pytest.fixture
-    def sample_chunks(cls):
+    def sample_chunks(self):
         """Create sample chunks for testing."""
         return [
             CodeChunk(
@@ -71,15 +70,13 @@ class TestChunkOptimizer:
             ),
         ]
 
-    @classmethod
     @pytest.fixture
-    def optimizer(cls):
+    def optimizer(self):
         """Create a ChunkOptimizer instance."""
         return ChunkOptimizer()
 
-    @classmethod
     @pytest.fixture
-    def mock_token_counter(cls):
+    def mock_token_counter(self):
         """Mock the token counter."""
         with patch("chunker.optimization.TiktokenCounter") as mock:
             counter = MagicMock()
@@ -382,9 +379,8 @@ class TestChunkOptimizer:
 class TestChunkBoundaryAnalyzer:
     """Test suite for ChunkBoundaryAnalyzer."""
 
-    @classmethod
     @pytest.fixture
-    def analyzer(cls):
+    def analyzer(self):
         """Create a ChunkBoundaryAnalyzer instance."""
         return ChunkBoundaryAnalyzer()
 
@@ -531,9 +527,8 @@ public class MyClass {
 class TestOptimizationIntegration:
     """Integration tests for optimization features."""
 
-    @classmethod
     @pytest.fixture
-    def real_optimizer(cls):
+    def real_optimizer(self):
         """Create optimizer with real token counter."""
         return ChunkOptimizer()
 
@@ -730,9 +725,8 @@ class TestOptimizationIntegration:
 class TestOptimizationEdgeCases:
     """Test edge cases and error handling."""
 
-    @classmethod
     @pytest.fixture
-    def optimizer(cls):
+    def optimizer(self):
         return ChunkOptimizer()
 
     @classmethod

--- a/tests/test_overlapping_fallback.py
+++ b/tests/test_overlapping_fallback.py
@@ -25,9 +25,8 @@ def _with_expected_fallback_warning(callback: Callable[[], T], match: str) -> T:
 class TestOverlappingFallbackChunker:
     """Test overlapping fallback chunker implementation."""
 
-    @classmethod
     @pytest.fixture
-    def chunker(cls):
+    def chunker(self):
         """Create an overlapping fallback chunker instance."""
         return OverlappingFallbackChunker()
 

--- a/tests/test_overlapping_fallback_isolated.py
+++ b/tests/test_overlapping_fallback_isolated.py
@@ -13,9 +13,8 @@ from chunker.fallback.overlapping import OverlappingFallbackChunker, OverlapStra
 class TestOverlappingFallbackChunker:
     """Test suite for overlapping fallback chunker."""
 
-    @classmethod
     @pytest.fixture
-    def chunker(cls):
+    def chunker(self):
         """Create a chunker instance."""
         return OverlappingFallbackChunker()
 

--- a/tests/test_query_advanced.py
+++ b/tests/test_query_advanced.py
@@ -16,15 +16,13 @@ from chunker.types import CodeChunk
 class TestNaturalLanguageQueryEngine:
     """Test natural language query engine."""
 
-    @classmethod
     @pytest.fixture
-    def query_engine(cls):
+    def query_engine(self):
         """Create query engine instance."""
         return NaturalLanguageQueryEngine()
 
-    @classmethod
     @pytest.fixture
-    def sample_chunks(cls):
+    def sample_chunks(self):
         """Create sample code chunks for testing."""
         return [
             CodeChunk(
@@ -253,15 +251,13 @@ class TestNaturalLanguageQueryEngine:
 class TestAdvancedQueryIndex:
     """Test advanced query index functionality."""
 
-    @classmethod
     @pytest.fixture
-    def index(cls):
+    def index(self):
         """Create index instance."""
         return AdvancedQueryIndex()
 
-    @classmethod
     @pytest.fixture
-    def sample_chunks(cls):
+    def sample_chunks(self):
         """Create sample chunks."""
         return [
             CodeChunk(
@@ -414,9 +410,8 @@ class TestAdvancedQueryIndex:
 class TestSmartQueryOptimizer:
     """Test query optimization functionality."""
 
-    @classmethod
     @pytest.fixture
-    def optimizer(cls):
+    def optimizer(self):
         """Create optimizer instance."""
         return SmartQueryOptimizer()
 
@@ -531,9 +526,8 @@ class TestSmartQueryOptimizer:
 class TestIntegration:
     """Integration tests for the complete query system."""
 
-    @classmethod
     @pytest.fixture
-    def query_system(cls):
+    def query_system(self):
         """Create complete query system."""
         engine = NaturalLanguageQueryEngine()
         index = AdvancedQueryIndex()

--- a/tests/test_relationship_tracker.py
+++ b/tests/test_relationship_tracker.py
@@ -11,9 +11,8 @@ from chunker.types import CodeChunk
 class TestASTRelationshipTracker:
     """Test AST-based relationship tracking."""
 
-    @classmethod
     @pytest.fixture
-    def tracker(cls):
+    def tracker(self):
         """Create a tracker instance."""
         return ASTRelationshipTracker()
 

--- a/tests/test_repo_processing.py
+++ b/tests/test_repo_processing.py
@@ -19,9 +19,8 @@ except ImportError:
 class TestRepoProcessor:
     """Test basic repository processor."""
 
-    @classmethod
     @pytest.fixture
-    def temp_repo(cls):
+    def temp_repo(self):
         """Create a temporary repository structure."""
         with tempfile.TemporaryDirectory() as tmpdir:
             repo_path = Path(tmpdir)
@@ -70,9 +69,8 @@ def test_goodbye():
             (repo_path / "docs" / "README.md").write_text("# Documentation")
             yield repo_path
 
-    @classmethod
     @pytest.fixture
-    def processor(cls):
+    def processor(self):
         """Create a repository processor."""
         return RepoProcessor(show_progress=False)
 
@@ -213,9 +211,8 @@ def greeting():
 class TestGitAwareRepoProcessor:
     """Test Git-aware repository processor."""
 
-    @classmethod
     @pytest.fixture
-    def git_repo(cls):
+    def git_repo(self):
         """Create a temporary git repository."""
         with tempfile.TemporaryDirectory() as tmpdir:
             repo_path = Path(tmpdir)
@@ -230,9 +227,8 @@ class TestGitAwareRepoProcessor:
             repo.index.commit("Initial commit")
             yield repo_path, repo
 
-    @classmethod
     @pytest.fixture
-    def git_processor(cls):
+    def git_processor(self):
         """Create a Git-aware repository processor."""
         return GitAwareRepoProcessor(show_progress=False)
 

--- a/tests/test_semantic_chunker.py
+++ b/tests/test_semantic_chunker.py
@@ -9,9 +9,8 @@ from chunker.strategies.semantic import SemanticChunker
 class TestSemanticChunker:
     """Test suite for SemanticChunker."""
 
-    @classmethod
     @pytest.fixture
-    def semantic_chunker(cls):
+    def semantic_chunker(self):
         """Create a semantic chunker instance."""
         return SemanticChunker()
 

--- a/tests/test_smart_context.py
+++ b/tests/test_smart_context.py
@@ -17,15 +17,13 @@ from chunker.types import CodeChunk
 class TestTreeSitterSmartContextProvider:
     """Test the TreeSitterSmartContextProvider implementation."""
 
-    @classmethod
     @pytest.fixture
-    def provider(cls):
+    def provider(self):
         """Create a smart context provider instance."""
         return TreeSitterSmartContextProvider()
 
-    @classmethod
     @pytest.fixture
-    def sample_chunks(cls):
+    def sample_chunks(self):
         """Create sample code chunks for testing."""
         chunks = [
             CodeChunk(

--- a/tests/test_template_generator.py
+++ b/tests/test_template_generator.py
@@ -11,16 +11,14 @@ from chunker.template_generator import TemplateGenerator
 class TestTemplateGenerator:
     """Test suite for TemplateGenerator."""
 
-    @classmethod
     @pytest.fixture
-    def temp_dir(cls):
+    def temp_dir(self):
         """Create a temporary directory for test outputs."""
         with tempfile.TemporaryDirectory() as tmpdir:
             yield Path(tmpdir)
 
-    @classmethod
     @pytest.fixture
-    def generator(cls):
+    def generator(self):
         """Create a TemplateGenerator instance."""
         return TemplateGenerator()
 

--- a/tests/test_wasm_language.py
+++ b/tests/test_wasm_language.py
@@ -11,9 +11,8 @@ from chunker.parser import get_parser
 class TestWASMPlugin:
     """Test suite for WebAssembly language plugin."""
 
-    @classmethod
     @pytest.fixture
-    def plugin(cls):
+    def plugin(self):
         """Create a WASM plugin instance."""
         return WASMPlugin()
 

--- a/tests/test_zig_language.py
+++ b/tests/test_zig_language.py
@@ -11,9 +11,8 @@ from chunker.parser import get_parser
 class TestZigPlugin:
     """Test suite for Zig language plugin."""
 
-    @classmethod
     @pytest.fixture
-    def plugin(cls):
+    def plugin(self):
         """Create a Zig plugin instance."""
         return ZigPlugin()
 

--- a/tests/unit/test_chunk_comparison.py
+++ b/tests/unit/test_chunk_comparison.py
@@ -13,15 +13,13 @@ from chunker.debug.tools.comparison import ChunkComparison
 class TestChunkComparison:
     """Unit tests for ChunkComparison class"""
 
-    @classmethod
     @pytest.fixture
-    def comparison(cls):
+    def comparison(self):
         """Create a ChunkComparison instance"""
         return ChunkComparison()
 
-    @classmethod
     @pytest.fixture
-    def test_file(cls):
+    def test_file(self):
         """Create a test Python file"""
         content = """def function1():
     pass

--- a/tests/unit/test_debug_visualization.py
+++ b/tests/unit/test_debug_visualization.py
@@ -15,15 +15,13 @@ from chunker.debug.tools.visualization import DebugVisualization
 class TestDebugVisualization:
     """Unit tests for DebugVisualization class"""
 
-    @classmethod
     @pytest.fixture
-    def visualizer(cls):
+    def visualizer(self):
         """Create a DebugVisualization instance"""
         return DebugVisualization()
 
-    @classmethod
     @pytest.fixture
-    def simple_python_file(cls):
+    def simple_python_file(self):
         """Create a simple Python file for testing"""
         content = "print('hello')"
         with tempfile.NamedTemporaryFile(


### PR DESCRIPTION
Mechanical collection-only fix of the pervasive @classmethod-over-@pytest.fixture decorator bug across the test suite (the P2 follow-up). No production/logic changes — the full suite now collects with 0 errors. Surfaced + pushed earlier by EX-tsc-hygiene; PR was never opened.