### PR TITLE
fix(cpp): register CppConfig + complete C++ boundary mapping (C# blocked on grammar ABI, deferred)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.0] - 2026-06-22
+
+### 🐛 Bug Fixes
+
+- **cpp**: Register a proper `CppConfig` so C++ extraction no longer falls back
+  to the generic default chunk types. Classes (`class_specifier` → `class`),
+  structs (`struct_specifier` → `struct`), namespaces (`namespace_definition` →
+  `module`), and in-class members are now emitted. In-class method declarations
+  and out-of-line `Class::method` definitions resolve to `method` (not bare
+  `function`); data members keep their own names (including pointer/reference
+  members) and remain `field_declaration`, matching the convention used by other
+  OO languages such as Java. Previously a C++ file extracted to only its
+  out-of-line `function_definition`s.
+
+### ✨ Features
+
+- New C++ boundary node-type mappings (additive; no change to other languages).
+  New boundaries are byte-reproducible and absolute-path-independent.
+
+
 ## [3.0.0] - 2026-06-21
 
 ### 📚 Documentation

--- a/chunker/core.py
+++ b/chunker/core.py
@@ -75,17 +75,21 @@ def _extract_definition_name(node: Node, source: bytes) -> str | None:
 
 
 def _extract_c_member_name(node: Node, source: bytes) -> str | None:
-    """Extract a name from C/C++ member and out-of-line definition nodes.
+    """Extract a name from C++ member and out-of-line definition nodes.
 
-    Handles the declarator shapes the generic ``name``/``identifier`` field
+    Handles the C++ declarator shapes the generic ``name``/``identifier`` field
     lookups miss:
-    - ``field_identifier`` (in-class data members, e.g. ``int total;``)
-    - ``function_declarator`` wrapping a method name (in-class declarations and
-      out-of-line definitions)
-    - ``qualified_identifier`` (out-of-line ``Class::method``), where the last
-      ``identifier`` segment is the unqualified name.
+    - ``field_identifier`` (in-class data members, e.g. ``int total;``, and
+      in-class method declarations whose name sits under a function_declarator)
+    - ``pointer_declarator`` / ``reference_declarator`` wrapping a
+      ``field_identifier`` (pointer/reference data members)
+    - ``qualified_identifier`` under a ``function_declarator`` (out-of-line
+      ``Class::method``), where the last ``identifier`` segment is the name.
 
-    Returns the unqualified name, or ``None`` if no name node is present.
+    Deliberately does NOT resolve a bare ``identifier`` under a
+    ``function_declarator`` (a C-style free function): the base lookups leave
+    those anonymous, and naming them would rewrite C qualified routes and
+    definition_ids. Returns the unqualified name, or ``None`` if none applies.
     """
     for child in getattr(node, "children", []) or []:
         child_type = getattr(child, "type", "")
@@ -110,11 +114,14 @@ def _extract_c_member_name(node: Node, source: bytes) -> str | None:
                     )
                 if sub_type == "qualified_identifier":
                     return _last_qualified_segment(sub, source)
-                if sub_type == "identifier":
-                    return source[sub.start_byte : sub.end_byte].decode(
-                        "utf-8",
-                        errors="ignore",
-                    )
+                # NOTE: deliberately do NOT resolve a plain `identifier` here.
+                # That shape is a C-style free function (`int add(){}`) which
+                # the base name lookups intentionally leave anonymous; resolving
+                # it would rewrite C qualified routes and definition_ids and
+                # break C's pinned IR. C++ in-class methods use `field_identifier`
+                # and out-of-line methods use `qualified_identifier` (handled
+                # above), so dropping this case loses nothing for C++. C++ free
+                # functions stay anonymous too, matching the C convention.
     return None
 
 

--- a/chunker/core.py
+++ b/chunker/core.py
@@ -64,7 +64,82 @@ def _extract_definition_name(node: Node, source: bytes) -> str | None:
                 errors="ignore",
             )
 
+    # C/C++ member and out-of-line definitions. The grammar buries the name
+    # under a function_declarator (for methods) or names a data member with a
+    # field_identifier directly, neither of which is exposed as a "name" field.
+    cpp_name = _extract_c_member_name(node, source)
+    if cpp_name is not None:
+        return cpp_name
+
     return None
+
+
+def _extract_c_member_name(node: Node, source: bytes) -> str | None:
+    """Extract a name from C/C++ member and out-of-line definition nodes.
+
+    Handles the declarator shapes the generic ``name``/``identifier`` field
+    lookups miss:
+    - ``field_identifier`` (in-class data members, e.g. ``int total;``)
+    - ``function_declarator`` wrapping a method name (in-class declarations and
+      out-of-line definitions)
+    - ``qualified_identifier`` (out-of-line ``Class::method``), where the last
+      ``identifier`` segment is the unqualified name.
+
+    Returns the unqualified name, or ``None`` if no name node is present.
+    """
+    for child in getattr(node, "children", []) or []:
+        child_type = getattr(child, "type", "")
+        if child_type == "field_identifier":
+            return source[child.start_byte : child.end_byte].decode(
+                "utf-8",
+                errors="ignore",
+            )
+        # Pointer/reference data members wrap the field_identifier in a
+        # (possibly nested) pointer_declarator / reference_declarator.
+        if child_type in {"pointer_declarator", "reference_declarator"}:
+            name = _extract_c_member_name(child, source)
+            if name is not None:
+                return name
+        if child_type == "function_declarator":
+            for sub in getattr(child, "children", []) or []:
+                sub_type = getattr(sub, "type", "")
+                if sub_type == "field_identifier":
+                    return source[sub.start_byte : sub.end_byte].decode(
+                        "utf-8",
+                        errors="ignore",
+                    )
+                if sub_type == "qualified_identifier":
+                    return _last_qualified_segment(sub, source)
+                if sub_type == "identifier":
+                    return source[sub.start_byte : sub.end_byte].decode(
+                        "utf-8",
+                        errors="ignore",
+                    )
+    return None
+
+
+def _last_qualified_segment(node: Node, source: bytes) -> str | None:
+    """Return the final unqualified identifier of a C++ qualified_identifier."""
+    current = node
+    # qualified_identifier nests (a::b::c -> a :: (b :: c)); descend to the leaf.
+    while True:
+        nested = None
+        leaf = None
+        for child in getattr(current, "children", []) or []:
+            child_type = getattr(child, "type", "")
+            if child_type == "qualified_identifier":
+                nested = child
+            elif child_type == "identifier":
+                leaf = child
+        if nested is not None:
+            current = nested
+            continue
+        if leaf is not None:
+            return source[leaf.start_byte : leaf.end_byte].decode(
+                "utf-8",
+                errors="ignore",
+            )
+        return None
 
 
 def _parse_route_segment(segment: str) -> tuple[str, str]:
@@ -473,6 +548,27 @@ def _walk(
                         adjusted_node_type = "method_definition"
                         break
                     parent = getattr(parent, "parent", None)
+        elif language == "cpp":
+            # C++ buries in-class methods inside `field_declaration` (a
+            # function_declarator marks a method vs. a data member) and writes
+            # out-of-line definitions as `function_definition` with a
+            # qualified_identifier (Class::method). Promote both to
+            # `method_declaration` so the emitted kind is `method` rather than
+            # `field`/`function`. Plain data members stay `field_declaration`
+            # (kind `field_declaration`), matching how Java emits fields.
+            if node.type == "field_declaration":
+                if any(
+                    getattr(child, "type", "") == "function_declarator"
+                    for child in node.children
+                ):
+                    adjusted_node_type = "method_declaration"
+            elif node.type == "function_definition":
+                declarator = node.child_by_field_name("declarator")
+                if declarator is not None and any(
+                    getattr(child, "type", "") == "qualified_identifier"
+                    for child in declarator.children
+                ):
+                    adjusted_node_type = "method_declaration"
         elif language == "julia":
             # Map Julia assignment nodes that are actually function definitions
             if node.type == "assignment":

--- a/chunker/languages/cpp.py
+++ b/chunker/languages/cpp.py
@@ -2,10 +2,44 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from .c import CPlugin
+from .base import language_config_registry
+from .c import CConfig, CPlugin
 
 if TYPE_CHECKING:
     from tree_sitter import Node
+
+
+class CppConfig(CConfig):
+    """Language configuration for C++ (inherits C's chunk types).
+
+    C++ shares C's struct/union/enum/typedef/function nodes and adds the
+    object-oriented surface: classes, namespaces, and in-class members. The
+    `field_declaration` node carries both data members and in-class method
+    declarations; the latter are promoted to ``method_declaration`` by the
+    C++-specific adjustment in ``core._walk`` so the emitted kind is ``method``
+    rather than ``field_declaration``.
+    """
+
+    @property
+    def language_id(self) -> str:
+        return "cpp"
+
+    @property
+    def chunk_types(self) -> set[str]:
+        """C++ chunk types: C's set plus the OO surface."""
+        return super().chunk_types | {
+            "class_specifier",
+            "namespace_definition",
+            "field_declaration",
+            "template_declaration",
+        }
+
+    @property
+    def file_extensions(self) -> set[str]:
+        return {".cpp", ".cxx", ".cc", ".hpp", ".hxx", ".hh"}
+
+
+language_config_registry.register(CppConfig())
 
 
 class CppPlugin(CPlugin):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name            = "treesitter-chunker"
-version = "3.0.0"
+version = "3.1.0"
 description     = "Semantic code chunker using Tree-sitter for intelligent code analysis"
 readme          = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_boundary_cpp.py
+++ b/tests/test_boundary_cpp.py
@@ -1,0 +1,108 @@
+"""Boundary IR extraction tests for the C++ object-oriented surface.
+
+These tests pin the fix for a C++ extraction defect surfaced by the parity
+engine: C++ had no ``CppConfig`` registered, so the chunker fell back to the
+generic default chunk types and emitted only ``function_definition`` chunks --
+classes, structs, namespaces, and in-class members were silently dropped.
+
+Assertions cover emitted *kinds*, *symbols*, and *qualified names* -- not just
+chunk counts -- because the kind/symbol mapping is the thing that regressed.
+"""
+
+from __future__ import annotations
+
+import collections
+
+from chunker.boundary import (
+    canonicalize_for_parity,
+    extract_boundary_ir,
+    parity_digest,
+)
+
+
+def _nodes_by_kind(nodes: list[dict]) -> dict[str, list[dict]]:
+    grouped: dict[str, list[dict]] = collections.defaultdict(list)
+    for node in nodes:
+        grouped[node["kind"]].append(node)
+    return grouped
+
+
+def _symbols(nodes: list[dict], kind: str) -> set[str | None]:
+    return {node.get("symbol") for node in nodes if node["kind"] == kind}
+
+
+def _qualified_names(nodes: list[dict], kind: str) -> set[str | None]:
+    return {node.get("qualified_name") for node in nodes if node["kind"] == kind}
+
+
+class TestCppBoundary:
+    """C++ now emits class/struct/namespace/method/field boundaries."""
+
+    @staticmethod
+    def test_class_with_inline_and_out_of_line_methods(tmp_path):
+        src = tmp_path / "gateway.cpp"
+        src.write_text(
+            "class Gateway { public: void send(); int count(); };\n"
+            "void Gateway::send(){}\n",
+        )
+        nodes = extract_boundary_ir(str(src), "cpp")["nodes"]
+        kinds = collections.Counter(node["kind"] for node in nodes)
+        # The class_specifier is emitted (previously dropped) ...
+        assert kinds["class"] == 1
+        assert _symbols(nodes, "class") == {"Gateway"}
+        # ... and the in-class member declarations resolve to `method`, not the
+        # bare `function` the generic fallback produced.
+        assert kinds["method"] >= 2
+        assert {"send", "count"} <= _symbols(nodes, "method")
+        # In-class methods carry the class-qualified name.
+        assert {"Gateway.send", "Gateway.count"} <= _qualified_names(nodes, "method")
+        # The out-of-line definition resolves to `method` (not `function`).
+        assert kinds.get("function", 0) == 0
+
+    @staticmethod
+    def test_namespace_struct_and_fields(tmp_path):
+        src = tmp_path / "net.cpp"
+        src.write_text(
+            "namespace net {\n"
+            "class Gateway {\n"
+            "public:\n"
+            "    void send();\n"
+            "    int total;\n"
+            "    int* buffer;\n"
+            "};\n"
+            "struct Packet { int len; };\n"
+            "}\n",
+        )
+        nodes = extract_boundary_ir(str(src), "cpp")["nodes"]
+        by_kind = _nodes_by_kind(nodes)
+        # namespace -> module (the repo's module-equivalent kind).
+        assert _symbols(nodes, "module") == {"net"}
+        # struct_specifier -> struct.
+        assert _symbols(nodes, "struct") == {"Packet"}
+        assert _qualified_names(nodes, "struct") == {"net.Packet"}
+        # class nested in the namespace carries the namespace-qualified name.
+        assert _qualified_names(nodes, "class") == {"net.Gateway"}
+        # Data members (incl. pointer members) keep their own names and stay
+        # `field_declaration` (matching how Java emits fields), not `method`.
+        field_symbols = _symbols(nodes, "field_declaration")
+        assert {"total", "buffer", "len"} <= field_symbols
+        # The method keeps `method` kind and is namespace+class qualified.
+        assert "net.Gateway.send" in _qualified_names(nodes, "method")
+        assert by_kind  # sanity: something was emitted
+
+    @staticmethod
+    def test_cpp_extraction_is_deterministic_and_path_independent(tmp_path):
+        body = "namespace a { class B { public: void f(); int g; }; }\n"
+        first = tmp_path / "one" / "x.cpp"
+        first.parent.mkdir()
+        first.write_text(body)
+        second = tmp_path / "two" / "x.cpp"
+        second.parent.mkdir()
+        second.write_text(body)
+
+        def digest(path) -> str:
+            doc = extract_boundary_ir(str(path), "cpp")
+            return parity_digest(canonicalize_for_parity(doc))
+
+        assert digest(first) == digest(first)  # byte-reproducible
+        assert digest(first) == digest(second)  # absolute-path independent

--- a/tests/test_cpp_language.py
+++ b/tests/test_cpp_language.py
@@ -1,14 +1,13 @@
 """Test C++-specific language features for the chunker.
 
-Note: The C++ language plugin (CppPlugin) exists and supports many C++ constructs
-including classes, namespaces, templates, constructors/destructors, etc. However,
-without a proper LanguageConfig registration (like Python has), the chunker falls
-back to default chunk types which only includes function_definition, class_definition,
-and method_definition.
-
-As a result, these tests verify that C++ code can be parsed and that functions/methods
-are properly detected, but more advanced chunking (classes, namespaces, templates as
-separate chunks) requires proper configuration setup.
+Note: C++ now registers a proper ``CppConfig`` in ``language_config_registry``
+(inheriting C's struct/union/enum/typedef/function types and adding the OO
+surface: ``class_specifier``, ``namespace_definition``, ``template_declaration``
+and in-class ``field_declaration`` members). Before that registration existed,
+``cpp`` had no config and the chunker fell back to the generic default chunk
+types ({function_definition, class_definition, method_definition}); classes,
+namespaces, and templates were silently dropped. These tests assert the
+corrected, richer extraction.
 """
 
 import importlib
@@ -57,9 +56,13 @@ auto add(T a, U b) -> decltype(a + b) {
 """,
         )
         chunks = chunk_file(test_file, "cpp")
-        assert len(chunks) == 2
-        for chunk in chunks:
-            assert chunk.node_type == "function_definition"
+        # Each templated function now emits both its wrapping
+        # `template_declaration` and the inner `function_definition` (previously
+        # the generic fallback only saw the two function_definitions).
+        function_chunks = [c for c in chunks if c.node_type == "function_definition"]
+        template_chunks = [c for c in chunks if c.node_type == "template_declaration"]
+        assert len(function_chunks) == 2
+        assert len(template_chunks) == 2
         assert any("max" in chunk.content for chunk in chunks)
         assert any("add" in chunk.content for chunk in chunks)
 
@@ -466,13 +469,17 @@ private:
 """,
         )
         chunks = chunk_file(test_file, "cpp")
+        # The enclosing `class_specifier` is now emitted as its own chunk (and
+        # its content contains every member), so scope member-level assertions
+        # to `function_definition` chunks to avoid double-counting the class.
         all_functions = [c for c in chunks if c.node_type == "function_definition"]
         assert len(all_functions) >= 7
-        constructor_like = [c for c in chunks if "Resource(" in c.content]
+        assert any(c.node_type == "class_specifier" for c in chunks)
+        constructor_like = [c for c in all_functions if "Resource(" in c.content]
         assert len(constructor_like) >= 3
-        destructor_like = [c for c in chunks if "~Resource" in c.content]
+        destructor_like = [c for c in all_functions if "~Resource" in c.content]
         assert len(destructor_like) >= 1
-        assignment_chunks = [c for c in chunks if "operator=" in c.content]
+        assignment_chunks = [c for c in all_functions if "operator=" in c.content]
         assert len(assignment_chunks) == 2
 
     @staticmethod

--- a/uv.lock
+++ b/uv.lock
@@ -2164,7 +2164,7 @@ wheels = [
 
 [[package]]
 name = "treesitter-chunker"
-version = "3.0.0"
+version = "3.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "chardet" },


### PR DESCRIPTION
## The defect

C++ boundary extraction was incomplete: a file like

```cpp
class Gateway { public: void send(); int count(); };
void Gateway::send(){}
```

extracted via `chunker.boundary.extract_boundary_ir(path, "cpp")` to only
`{function: 1}` — the out-of-line `function_definition`. The `class_specifier`,
the in-class member declarations, and `struct_specifier` / `namespace_definition`
were all silently dropped.

### Root cause

The `chunk_file` -> `core._walk` extraction path is **config-driven** via
`language_config_registry`. No `CppConfig` was ever registered (`R.get("cpp")`
returned `None`) — only the `CppPlugin`/`CConfig` classes exist, and the
`*Plugin` classes are **not** on the `_walk` path. With no config, `_walk` fell
to the generic default chunk types (`{function_definition, class_definition,
method_definition}`); C++ classes are `class_specifier`, which never matched.

## The fix (C++)

- **Register `CppConfig`** (`chunker/languages/cpp.py`), inheriting C's
  struct/union/enum/typedef/function chunk types and adding the OO surface:
  `class_specifier`, `namespace_definition`, `field_declaration`,
  `template_declaration`. This mirrors how `CConfig`/`JavaConfig` register.
- **Per-language adjustment in `core._walk`** (the same pattern dart/scala/elixir
  use): in-class `field_declaration` carrying a `function_declarator` is promoted
  to `method` (vs `field`); out-of-line `function_definition` with a
  `qualified_identifier` declarator (`Class::method`) is promoted to `method`
  (vs bare `function`). Plain data members stay `field_declaration`, matching how
  Java emits fields.
- **Extend `_extract_definition_name`** to recover C/C++ member names the generic
  `name`/`identifier` field lookups miss: `field_identifier`,
  `function_declarator`, nested `qualified_identifier`, and pointer/reference
  declarators.

### Node-type -> kind mappings added (C++)

| tree-sitter node | emitted kind | symbol |
|---|---|---|
| `class_specifier` | `class` | class name |
| `struct_specifier` | `struct` | struct name |
| `namespace_definition` | `module` | namespace name |
| in-class `field_declaration` + `function_declarator` | `method` | method name |
| in-class `field_declaration` (data) | `field_declaration` | member name |
| out-of-line `function_definition` (`Class::method`) | `method` | method name |

`module` is the repo's existing namespace/package-equivalent kind
(`core._normalize_kind`); `field_declaration` matches the kind Java already emits
for fields (no language emits a bare `field` kind). Out-of-line definitions
resolve to `method` but keep the unqualified symbol/qualified-name — recovering
the full `Class::` scope is left out as the briefing's "don't over-reach" case.

## How it matches existing OO-language conventions

`CppConfig` registers exactly like `CConfig`/`JavaConfig`; kind normalization
flows through the same `core._normalize_kind`; the `_walk` adjustment block is
the established mechanism for grammar-specific node reshaping. No special-casing
outside these conventions.

## Tests

- New `tests/test_boundary_cpp.py` — asserts emitted **kinds + symbols +
  qualified names** (not just counts) for class/struct/namespace/method/field,
  plus byte-reproducibility and absolute-path independence.
- `tests/test_cpp_language.py` — two tests (`test_template_function`,
  `test_constructor_destructor`) had encoded the *buggy* function-only behavior
  (the module docstring even described the missing-config bug); updated to the
  corrected richer extraction, justified inline.

## Other languages unchanged (byte-verified)

`_extract_definition_name` is generic, so C correctness is checked at the **IR
byte level**, not just test counts: the canonical Boundary IR for two C samples
— `struct` + functions, and a broad sample (typedef / function pointer /
function-returning-pointer / enum / union / nested struct-in-function) — is
**byte-identical** between baseline (`97d65f51`) and this branch.

(An earlier revision of the C/C++ name helper did perturb C: it resolved
C-style free-function names that the base lookups intentionally leave anonymous,
which rewrote C qualified routes / `definition_id`s. That was caught by the
byte-level diff and fixed by dropping the bare-`identifier` branch — C++ in-class
methods use `field_identifier` and out-of-line methods use `qualified_identifier`,
so C++ is unaffected; C++ free functions stay anonymous like C. See the second
commit on this branch.)

Running the 21 test files that contain any failure, baseline vs this branch:
**0 new failures** (all remaining failures are pre-existing infrastructure
issues — grammar build, registry isolation, phase3 integration harness,
perf/parquet env). Lint clean (ruff, black, isort). Wheel verified
`pip install`-able.

## Version

`3.0.0` -> `3.1.0` (additive minor — new C++ boundary kinds, no change to
existing languages). CHANGELOG updated. **RELEASE-READY, not published** — the
publish step is left for human approval.

## C# is deliberately NOT in this PR

C#'s existing `CSharpConfig` is already correct; the defect is that the only
available C# grammar (`tree-sitter-c-sharp>=0.23.1`, hard-pinned transitively by
`tree-sitter-language-pack 0.9.0`) is grammar **ABI 15** and cannot load under
the ABI-paired `tree_sitter 0.24` (ABI <=14) — so C# fails to parse entirely.
No constraint expressible in published wheel metadata can hand a pip consumer a
working C# while the pack pins the broken grammar (a `[tool.uv]` override fixes
the local env but is **not** written into wheel metadata; with the override a
built wheel becomes `pip install` `ResolutionImpossible`). C# is held for a
separate PR gated on a real grammar-packaging fix (upstream pack bump, or a
vendored ABI-14 grammar). The C# extraction fix itself is understood and ready
to revive once the packaging blocker is resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FaExgRE81DNhPpHZDcUvLY
