### PR TITLE
feat: C# boundary extraction via ABI-14 grammar override (additive 3.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.0] - 2026-06-24
+
+### ✨ Features
+
+- **csharp**: C# boundary extraction via an ABI-14 grammar override. C# previously
+  emitted nothing: tree-sitter-language-pack 0.9.0 pulls
+  `tree-sitter-c-sharp==0.23.1` (tree-sitter ABI 15) transitively, but the pinned
+  `tree_sitter==0.24` core caps at ABI 14, so the grammar failed to load
+  ("Incompatible Language version 15. Must be between 13 and 14"), the error was
+  swallowed, and the chunker produced `{}`. A `[tool.uv] override-dependencies`
+  entry pins the ABI-14 `tree-sitter-c-sharp==0.23.0`, which loads under
+  `tree_sitter 0.24` and parses C# richly. C# now emits
+  namespace (→ `module`) / class / method / field / enum / property boundaries.
+  Also adds `namespace_declaration` + `file_scoped_namespace_declaration` to the
+  C# chunk types, and canonicalizes the `c_sharp` language alias to `csharp` so
+  both aliases collect `.cs` files and produce byte-identical Boundary IR.
+  This change is purely additive: only C# gains coverage; the canonical Boundary
+  IR for every other language (C, C++, Java, Python, Go, Rust, TypeScript) is
+  byte-for-byte unchanged (verified by canonical-IR byte-diff against 3.1.0).
+
+  > **Note:** the `[tool.uv]` override is root-only and is **not** packaged into
+  > the wheel/sdist. A plain `pip install treesitter-chunker==3.2.0` resolves the
+  > ABI-15 `tree-sitter-c-sharp` and C# extraction stays empty. Consumers that
+  > need C# boundaries must pin `tree-sitter-c-sharp==0.23.0` in their **own** uv
+  > root (or `pip install tree-sitter-c-sharp==0.23.0`). See PR #78.
+
 ## [3.1.0] - 2026-06-23
 
 ### 🐛 Bug Fixes

--- a/chunker/boundary/adapter.py
+++ b/chunker/boundary/adapter.py
@@ -12,6 +12,7 @@ from typing import Any
 from chunker.auto import ZeroConfigAPI
 from chunker.core import chunk_file
 from chunker.symbol_graph import (
+    _canonical_language,
     assemble_symbol_graph,
     collect_source_files,
     extract_symbol_facts_for_file,
@@ -74,7 +75,9 @@ def _module_name(display_path: str) -> str:
 
 def _detect_language(file_path: Path, fallback: str | None) -> str | None:
     if fallback:
-        return fallback.lower()
+        # Canonicalize aliases (e.g. "c_sharp" -> "csharp") so the alias resolves
+        # to the same config and hashes identically to the canonical name.
+        return _canonical_language(fallback)
     return ZeroConfigAPI.EXTENSION_MAP.get(file_path.suffix.lower())
 
 
@@ -963,6 +966,11 @@ def extract_boundary_ir(
     if resolution_mode not in RESOLUTION_MODES:
         msg = f"Unsupported resolution_mode: {resolution_mode}"
         raise ValueError(msg)
+    # Canonicalize language aliases (e.g. "c_sharp" -> "csharp") once, so every
+    # downstream consumer — file collection, graph assembly, and the echoed
+    # run.options.language — sees the canonical value and the IR is byte-identical
+    # regardless of which alias the caller passed.
+    language = _canonical_language(language)
     _validate_semantic_min_confidence(semantic_min_confidence)
     semantic_resolvers = (
         None if semantic_resolvers is None else tuple(semantic_resolvers)

--- a/chunker/languages/cs.py
+++ b/chunker/languages/cs.py
@@ -19,6 +19,11 @@ class CSharpConfig(LanguageConfig):
     def chunk_types(self) -> set[str]:
         # Common C# tree-sitter node types of interest
         return {
+            # Namespace surface — both the block form (`namespace N { ... }`) and
+            # the C# 10 file-scoped form (`namespace N;`). Both normalize to kind
+            # "module" via core._normalize_kind, matching C++'s namespace_definition.
+            "namespace_declaration",
+            "file_scoped_namespace_declaration",
             "class_declaration",
             "struct_declaration",
             "interface_declaration",

--- a/chunker/symbol_graph.py
+++ b/chunker/symbol_graph.py
@@ -42,11 +42,27 @@ _IMPORT_KEYWORDS = {
 }
 
 
+# Canonicalize language aliases to the value used in EXTENSION_MAP. The C#
+# registry registers language_id "c_sharp" with alias "csharp", but
+# EXTENSION_MAP maps ".cs" -> "csharp"; without this, passing language
+# "c_sharp" matches no extension and collects zero files. Canonicalizing here
+# (and in adapter._detect_language) makes the "c_sharp" alias resolve to the
+# same files and hash identically to "csharp".
+_LANGUAGE_ALIASES: dict[str, str] = {"c_sharp": "csharp"}
+
+
+def _canonical_language(language: str | None) -> str | None:
+    if language is None:
+        return None
+    lowered = language.lower()
+    return _LANGUAGE_ALIASES.get(lowered, lowered)
+
+
 def _candidate_extensions(language: str | None) -> set[str]:
     extension_map = ZeroConfigAPI.EXTENSION_MAP
     if language is None:
         return set(extension_map)
-    normalized = language.lower()
+    normalized = _canonical_language(language)
     return {ext for ext, lang in extension_map.items() if lang == normalized}
 
 
@@ -80,7 +96,7 @@ def _detect_language(
     file_path: Path, fallback_language: str | None = None
 ) -> str | None:
     if fallback_language:
-        return fallback_language.lower()
+        return _canonical_language(fallback_language)
     return ZeroConfigAPI.EXTENSION_MAP.get(file_path.suffix.lower())
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name            = "treesitter-chunker"
-version = "3.1.0"
+version = "3.2.0"
 description     = "Semantic code chunker using Tree-sitter for intelligent code analysis"
 readme          = "README.md"
 requires-python = ">=3.11"
@@ -106,6 +106,20 @@ requires = [
     # "setuptools-scm[toml]>=6.2",
 ]
 build-backend = "setuptools.build_meta"
+
+
+[tool.uv]
+# C# boundary extraction requires an ABI-14 grammar. tree-sitter-language-pack
+# 0.9.x transitively hard-pins tree-sitter-c-sharp>=0.23.1, which is built against
+# tree-sitter ABI 15. Our verified pairing caps the core at tree_sitter 0.24
+# (ABI 13-14), so the 0.23.1 grammar fails to load
+# ("Incompatible Language version 15. Must be between 13 and 14") and C# silently
+# emits zero boundaries. tree-sitter-c-sharp 0.23.0 is ABI 14 and loads + parses
+# C# richly (class/method/field/enum) under tree_sitter 0.24. A plain dependency
+# constraint is unsatisfiable against the pack's transitive >=0.23.1 hard-pin, so
+# this MUST be an override. Additive: only C# changes; the 0.24/0.9 pairing for
+# every other language is untouched.
+override-dependencies = ["tree-sitter-c-sharp==0.23.0"]
 
 
 

--- a/tests/test_boundary_csharp.py
+++ b/tests/test_boundary_csharp.py
@@ -1,0 +1,147 @@
+"""Boundary IR extraction tests for the C# surface.
+
+These tests pin the fix for a C# extraction defect surfaced by the parity
+engine: ``CSharpConfig`` was complete, but C# emitted *nothing*. The C# grammar
+that tree-sitter-language-pack 0.9.0 pulls transitively is
+``tree-sitter-c-sharp==0.23.1``, built against tree-sitter ABI 15; the pinned
+``tree_sitter==0.24`` core caps at ABI 14, so the grammar failed to load
+("Incompatible Language version 15. Must be between 13 and 14"), the error was
+swallowed, and the chunker produced ``{}``. The fix pins the ABI-14
+``tree-sitter-c-sharp==0.23.0`` via a ``[tool.uv] override-dependencies`` entry
+(additive: only C# changes).
+
+A second defect is also pinned here: ``EXTENSION_MAP`` maps ``.cs`` -> ``csharp``
+while the registry's ``language_id`` is ``c_sharp``, so passing the ``c_sharp``
+alias collected zero files. Language aliases are now canonicalized so both
+``csharp`` and ``c_sharp`` resolve to the same files and hash identically.
+
+Assertions cover emitted *kinds*, *symbols*, and *qualified names* -- not just
+chunk counts -- because the kind/symbol mapping is the thing that regressed.
+"""
+
+from __future__ import annotations
+
+import collections
+
+from chunker.boundary import (
+    canonicalize_for_parity,
+    dumps_boundary_ir,
+    extract_boundary_ir,
+    parity_digest,
+)
+
+# A namespace + class (with field, method, property) + enum -- the full surface
+# named in the exit criteria.
+SAMPLE = (
+    "namespace MyApp.Core\n"
+    "{\n"
+    "    public enum Status { Active, Inactive }\n"
+    "\n"
+    "    public class Widget\n"
+    "    {\n"
+    "        private int _count;\n"
+    "\n"
+    "        public int Increment(int by)\n"
+    "        {\n"
+    "            _count += by;\n"
+    "            return _count;\n"
+    "        }\n"
+    "\n"
+    "        public string Name { get; set; }\n"
+    "    }\n"
+    "}\n"
+)
+
+
+def _symbols(nodes: list[dict], kind: str) -> set[str | None]:
+    return {node.get("symbol") for node in nodes if node["kind"] == kind}
+
+
+def _qualified_names(nodes: list[dict], kind: str) -> set[str | None]:
+    return {node.get("qualified_name") for node in nodes if node["kind"] == kind}
+
+
+class TestCSharpBoundary:
+    """C# now emits namespace/class/method/field/enum/property boundaries."""
+
+    @staticmethod
+    def test_namespace_class_enum_method_field_property(tmp_path):
+        src = tmp_path / "Sample.cs"
+        src.write_text(SAMPLE)
+        nodes = extract_boundary_ir(str(src), "csharp")["nodes"]
+        kinds = collections.Counter(node["kind"] for node in nodes)
+
+        # The namespace surfaces as `module` (the repo's namespace-equivalent
+        # kind), matching how C++ emits namespace_definition.
+        assert kinds["module"] == 1
+        assert _symbols(nodes, "module") == {"MyApp.Core"}
+
+        # The class is emitted and namespace-qualified.
+        assert kinds["class"] == 1
+        assert _symbols(nodes, "class") == {"Widget"}
+        assert _qualified_names(nodes, "class") == {"MyApp.Core.Widget"}
+
+        # The enum is emitted and namespace-qualified.
+        assert kinds["enum"] == 1
+        assert _symbols(nodes, "enum") == {"Status"}
+        assert _qualified_names(nodes, "enum") == {"MyApp.Core.Status"}
+
+        # The method resolves to `method` and carries the class-qualified name.
+        assert kinds["method"] == 1
+        assert _symbols(nodes, "method") == {"Increment"}
+        assert "MyApp.Core.Widget.Increment" in _qualified_names(nodes, "method")
+
+        # Fields stay `field_declaration` (matching how Java/C++ emit fields).
+        assert kinds["field_declaration"] == 1
+
+        # Properties stay `property_declaration` and carry the class-qualified name.
+        assert kinds["property_declaration"] == 1
+        assert "MyApp.Core.Widget.Name" in _qualified_names(
+            nodes, "property_declaration"
+        )
+
+    @staticmethod
+    def test_file_scoped_namespace(tmp_path):
+        src = tmp_path / "FileScoped.cs"
+        src.write_text(
+            "namespace MyApp.Tools;\n"
+            "public class Helper {\n"
+            "    public void Run() {}\n"
+            "}\n"
+        )
+        nodes = extract_boundary_ir(str(src), "csharp")["nodes"]
+        # The C# 10 file-scoped namespace form also surfaces as `module`.
+        assert _symbols(nodes, "module") == {"MyApp.Tools"}
+        assert _symbols(nodes, "class") == {"Helper"}
+
+    @staticmethod
+    def test_csharp_and_c_sharp_aliases_hash_identically(tmp_path):
+        src = tmp_path / "Sample.cs"
+        src.write_text(SAMPLE)
+
+        def canonical_bytes(language: str) -> str:
+            doc = extract_boundary_ir(str(src), language)
+            return dumps_boundary_ir(canonicalize_for_parity(doc))
+
+        # The `c_sharp` alias (registry language_id) and `csharp` (EXTENSION_MAP
+        # value + display name) must collect the same files and produce a
+        # byte-identical canonical IR.
+        assert canonical_bytes("csharp") == canonical_bytes("c_sharp")
+        # And both emit the full boundary set (not the previous empty result).
+        assert len(extract_boundary_ir(str(src), "c_sharp")["nodes"]) == 6
+
+    @staticmethod
+    def test_csharp_extraction_is_deterministic_and_path_independent(tmp_path):
+        first = tmp_path / "one" / "x.cs"
+        first.parent.mkdir()
+        first.write_text(SAMPLE)
+        second = tmp_path / "two" / "x.cs"
+        second.parent.mkdir()
+        second.write_text(SAMPLE)
+
+        def digest(path) -> str:
+            doc = extract_boundary_ir(str(path), "csharp")
+            return parity_digest(canonicalize_for_parity(doc))
+
+        assert digest(first) == digest(first)  # byte-reproducible
+        assert digest(first) == digest(second)  # absolute-path independent

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,9 @@ version = 1
 revision = 3
 requires-python = ">=3.11"
 
+[manifest]
+overrides = [{ name = "tree-sitter-c-sharp", specifier = "==0.23.0" }]
+
 [[package]]
 name = "alabaster"
 version = "1.0.0"
@@ -2091,25 +2094,16 @@ wheels = [
 
 [[package]]
 name = "tree-sitter-c-sharp"
-version = "0.23.1"
+version = "0.23.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/22/85/a61c782afbb706a47d990eaee6977e7c2bd013771c5bf5c81c617684f286/tree_sitter_c_sharp-0.23.1.tar.gz", hash = "sha256:322e2cfd3a547a840375276b2aea3335fa6458aeac082f6c60fec3f745c967eb", size = 1317728, upload-time = "2024-11-11T05:25:32.535Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4c/dc/d4a0ad9e466263728f80f9dac399609473af01c1aba2ea3ea8879ce56276/tree_sitter_c_sharp-0.23.1-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:e87be7572991552606a3155d2f6c2045ded8bce94bfd9f74bf521d949c219a1c", size = 333661, upload-time = "2026-04-14T15:11:14.227Z" },
-    { url = "https://files.pythonhosted.org/packages/61/7a/5c862770460a2e27079e725585ad2718100373c09448c14e36934ef44414/tree_sitter_c_sharp-0.23.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:86c2fdf178c66474a1be2965602818d30780e4e3ed890e3c206931f65d9a154c", size = 376295, upload-time = "2026-04-14T15:11:15.346Z" },
-    { url = "https://files.pythonhosted.org/packages/67/18/0571a3a34c0feda60a9c37cf6dd5edfdbc24f8fcb1e48b6b6eb0f324ad2a/tree_sitter_c_sharp-0.23.1-cp310-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:035d259e64c41d02cc45afc3b8b46388b232e7d16d84734d851cca7334761da5", size = 358331, upload-time = "2026-04-14T15:11:16.418Z" },
-    { url = "https://files.pythonhosted.org/packages/44/65/0f7e1f50f6365338eb700f01710da0adc49a49fa9a8443e5a90ea4f29491/tree_sitter_c_sharp-0.23.1-cp310-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fa472cb9de7e14fee9408e144f29f68384cd8e9c677dff0002da19f361a59bdf", size = 359444, upload-time = "2026-04-14T15:11:17.509Z" },
-    { url = "https://files.pythonhosted.org/packages/98/60/129bd56d5ef22b4ae254940a09b6d3ed873093218868a3f9635d571d514e/tree_sitter_c_sharp-0.23.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1a0ea86eccff74e85ab4a2cf77c813fad7c84162962ce242dff0c51601028832", size = 358143, upload-time = "2026-04-14T15:11:18.755Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/cd/e12cdca47e0c56151cb4b156d48091b7bc1d968e072c1656cf6b73fe7218/tree_sitter_c_sharp-0.23.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8ab26dc998bbd4b4287b129f67c10ca715deb402ed77d0645674490ea509097e", size = 357524, upload-time = "2026-04-14T15:11:19.717Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/2c/f742d60f818cba83760f4975c7158d1c96c36b5807e95a843db7fb8c64b7/tree_sitter_c_sharp-0.23.1-cp310-abi3-win_amd64.whl", hash = "sha256:d4486653feaff3314ef45534dcb6f9ea8ab3aa160896287c6473788f88eb38be", size = 338755, upload-time = "2026-04-14T15:11:20.883Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/e4/8a8642b9bba86248ac2facc81ffb187c06c6768efa56c79d61fab70d736b/tree_sitter_c_sharp-0.23.1-cp310-abi3-win_arm64.whl", hash = "sha256:e7a14b76ec23cc8386cf662d5ea602d81331376c93ca6299a97b174047790345", size = 337261, upload-time = "2026-04-14T15:11:22.111Z" },
-    { url = "https://files.pythonhosted.org/packages/58/04/f6c2df4c53a588ccd88d50851155945cff8cd887bd70c175e00aaade7edf/tree_sitter_c_sharp-0.23.1-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:2b612a6e5bd17bb7fa2aab4bb6fc1fba45c94f09cb034ab332e45603b86e32fd", size = 372235, upload-time = "2024-11-11T05:25:19.424Z" },
-    { url = "https://files.pythonhosted.org/packages/99/10/1aa9486f1e28fc22810fa92cbdc54e1051e7f5536a5e5b5e9695f609b31e/tree_sitter_c_sharp-0.23.1-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a8b98f62bc53efcd4d971151950c9b9cd5cbe3bacdb0cd69fdccac63350d83e", size = 419046, upload-time = "2024-11-11T05:25:20.679Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/21/13df29f8fcb9ba9f209b7b413a4764b673dfd58989a0dd67e9c7e19e9c2e/tree_sitter_c_sharp-0.23.1-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:986e93d845a438ec3c4416401aa98e6a6f6631d644bbbc2e43fcb915c51d255d", size = 415999, upload-time = "2024-11-11T05:25:22.359Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/72/fc6846795bcdae2f8aa94cc8b1d1af33d634e08be63e294ff0d6794b1efc/tree_sitter_c_sharp-0.23.1-cp39-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a8024e466b2f5611c6dc90321f232d8584893c7fb88b75e4a831992f877616d2", size = 402830, upload-time = "2024-11-11T05:25:24.198Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/3a/b6028c5890ce6653807d5fa88c72232c027c6ceb480dbeb3b186d60e5971/tree_sitter_c_sharp-0.23.1-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:7f9bf876866835492281d336b9e1f9626ab668737f74e914c31d285261507da7", size = 397880, upload-time = "2024-11-11T05:25:25.937Z" },
-    { url = "https://files.pythonhosted.org/packages/47/d2/4facaa34b40f8104d8751746d0e1cd2ddf0beb9f1404b736b97f372bd1f3/tree_sitter_c_sharp-0.23.1-cp39-abi3-win_amd64.whl", hash = "sha256:ae9a9e859e8f44e2b07578d44f9a220d3fa25b688966708af6aa55d42abeebb3", size = 377562, upload-time = "2024-11-11T05:25:27.539Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/88/3cf6bd9959d94d1fec1e6a9c530c5f08ff4115a474f62aedb5fedb0f7241/tree_sitter_c_sharp-0.23.1-cp39-abi3-win_arm64.whl", hash = "sha256:c81548347a93347be4f48cb63ec7d60ef4b0efa91313330e69641e49aa5a08c5", size = 375157, upload-time = "2024-11-11T05:25:30.839Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/11/a1be9a4531e3fc766ba2e0634b7c6ba68388ccbbc85792080c8ff26a9b14/tree_sitter_c_sharp-0.23.0-cp38-abi3-macosx_10_9_x86_64.whl", hash = "sha256:c3db2a24a5cee7800473a12bb15ef38c95131c89ae4c76fd1ebf0339227a1ee2", size = 369888, upload-time = "2024-09-01T10:03:59.572Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/ac/917e31a7f100b438320d425b453def4c663640c0bc0c36abb7eadae371ef/tree_sitter_c_sharp-0.23.0-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:715a2a70869a8dc845a408a2758a1c7d958fd6d1db3205ee116a1c8c3f1b5b96", size = 416643, upload-time = "2024-09-01T10:04:01.02Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/b3/4098be7360af74d9603d0ce264c4d52ca4ef2f5fcef8daa96910208bec68/tree_sitter_c_sharp-0.23.0-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8b10c4670747fcaf5276355c7aec4b8d189b02f3efbf8b9cf81d3814514048fe", size = 412909, upload-time = "2024-09-01T10:04:02.327Z" },
+    { url = "https://files.pythonhosted.org/packages/56/be/e20bb812af1ea4c35d901b3a6bf95a6c18cfb8710c5a4d26d250053e615e/tree_sitter_c_sharp-0.23.0-cp38-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cbcb8b5cb498a19ff48c03828b0ab08d3778fdbbdee72ce6436b2de270b21d4b", size = 400447, upload-time = "2024-09-01T10:04:03.466Z" },
+    { url = "https://files.pythonhosted.org/packages/17/2f/695aba99aa2d565c5bbfa8603fa7608e23bd56885fc058d44f4890f28ab8/tree_sitter_c_sharp-0.23.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:382add46deaea95e4c233c21a8f555f70b4f5c0a28d4a2fa56ea34e25979af64", size = 395530, upload-time = "2024-09-01T10:04:04.709Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/14/fc8a881e6738b532a5b6ac01d534f529379c4d701859df002eb04f9b3c26/tree_sitter_c_sharp-0.23.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:596eb9ee60c55beed0885700dc085e573f053f3179fe0b4240c62a23c470a869", size = 395292, upload-time = "2024-09-01T10:04:05.83Z" },
+    { url = "https://files.pythonhosted.org/packages/00/2a/157849b6e0e8325fdd862339710bb535a8f174aca4311d9ddacf0ca69af8/tree_sitter_c_sharp-0.23.0-cp38-abi3-win_amd64.whl", hash = "sha256:bbfb1b5679bb0f76912741969c7ab8bb33f2482d5e24a33ce11e3291a1309110", size = 375234, upload-time = "2024-09-01T10:04:07.504Z" },
 ]
 
 [[package]]
@@ -2164,7 +2158,7 @@ wheels = [
 
 [[package]]
 name = "treesitter-chunker"
-version = "3.1.0"
+version = "3.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "chardet" },


### PR DESCRIPTION
## Summary

C# previously emitted **nothing** from the boundary-IR extractor. This PR makes C# emit namespace / class / method / field / enum / property boundaries as an **additive 3.2.0 minor** — no other language changes.

## Root cause (ABI 15 vs ABI 14)

`tree-sitter-language-pack==0.9.0` pulls `tree-sitter-c-sharp==0.23.1` transitively, which is built against **tree-sitter ABI 15**. The repo's verified, ABI-paired core is `tree_sitter==0.24` (caps at **ABI 14**). So the C# grammar failed to load:

```
ValueError: Incompatible Language version 15. Must be between 13 and 14
```

That error was swallowed, and the chunker silently produced `{}` for C#.

## The fix (additive, C#-only)

1. **ABI-14 grammar override.** The pack hard-pins `tree-sitter-c-sharp>=0.23.1` transitively, so a plain dependency constraint is unsatisfiable — this MUST be an override:

   ```toml
   [tool.uv]
   override-dependencies = ["tree-sitter-c-sharp==0.23.0"]
   ```

   `tree-sitter-c-sharp==0.23.0` is **ABI 14**; it loads under `tree_sitter 0.24` (`abi_version == 14`, `has_error == False`) and parses C# richly. The 0.24/0.9 ABI pairing for every other language is **untouched**.

2. **Namespace surface.** Added `namespace_declaration` + `file_scoped_namespace_declaration` to `CSharpConfig.chunk_types`. Both forms normalize to kind `module` via `core._normalize_kind`, matching how C++ emits `namespace_definition`.

3. **`c_sharp` alias fix.** `EXTENSION_MAP` maps `.cs` -> `csharp`, but the registry's `language_id` is `c_sharp`, so passing language `c_sharp` collected **zero** files. Language aliases are now canonicalized (`c_sharp` -> `csharp`) in `symbol_graph._candidate_extensions`/`_detect_language` and `adapter.extract_boundary_ir` (covering the echoed `run.options.language` too), so both aliases collect `.cs` and produce **byte-identical** Boundary IR.

## C# boundaries now emitted

For a namespace + class (field, method, property) + enum fixture, both `csharp` and `c_sharp` emit 6 boundaries: `module` (namespace `MyApp.Core`), `class` (`MyApp.Core.Widget`), `enum` (`MyApp.Core.Status`), `method` (`MyApp.Core.Widget.Increment`), `field_declaration`, `property_declaration` (`MyApp.Core.Widget.Name`).

`field_declaration`/`property_declaration` deliberately stay raw — `field_declaration` mirrors how **Java and C++ already emit fields** (verified), so no kind-taxonomy is changed.

## No-regression proof (canonical-IR byte-diff)

For each non-C# language I computed `dumps_boundary_ir(canonicalize_for_parity(extract_boundary_ir(...)))` in this branch and in a clean baseline worktree at `main` (`bcf38add`, which still carries the broken `tree-sitter-c-sharp==0.23.1`), and compared SHA-256:

| language | baseline == fix |
|---|---|
| C (typedef / function-pointer / func-returning-pointer / enum / union / nested struct) | identical |
| C++ | identical |
| Java | identical |
| Python | identical |
| Go | identical |
| Rust | identical |
| TypeScript | identical |

**Zero-byte difference** for every non-C# language. C# is purely additive.

## ⚠️ Known limitation: the override is root-only and does NOT survive packaging

`[tool.uv] override-dependencies` is honored **only when chunker is the uv root** (CI, local dev, this PR's tests). It is **not** packaged into the wheel/sdist, and uv overrides do not propagate to downstream consumers. Verified empirically:

- **`pip install` of the built 3.2.0 wheel** into a clean venv resolves `tree-sitter-c-sharp==0.23.5` (ABI 15) → C# extracts **0 nodes** again (original bug returns).
- A downstream consumer (e.g. the spec parity engine) that is itself the uv root applies **its own** overrides, not chunker's.

**Therefore:** any environment that needs C# boundaries must pin the ABI-14 grammar in **its own** root, e.g.:

```toml
[tool.uv]
override-dependencies = ["tree-sitter-c-sharp==0.23.0"]
```

or `pip install 'tree-sitter-c-sharp==0.23.0'` after installing chunker. This is inherent to the uv-override approach; a packaging-surviving fix would require a hard dependency pin or vendoring, which is out of scope for this additive change.

## Tests

- New `tests/test_boundary_csharp.py`: kinds + symbols + qualified names for namespace/class/enum/method/field/property; `csharp` and `c_sharp` aliases hash identically; file-scoped namespace; deterministic + path-independent digest.
- Pre-existing `tests/test_phase15_languages.py::...test_csharp_property_access` was failing on `main` and now **passes** (net +1). Remaining phase15 call-graph failures are pre-existing and broadly cross-language, unrelated to boundary IR.

Version bumped 3.1.0 -> **3.2.0** (additive minor) + CHANGELOG entry. Not published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017NXPoyNcnXay4n3ay7spkz