### PR TITLE
feat: boundary-IR determinism gate (golden coverage for all languages + non-empty & pin guards)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,10 @@ logs/
 .pubenv/
 .stow-symbols.json
 /.dev-skills/
+
+# Boundary IR golden fixtures are first-class committed test data. The
+# "test repositories (downloaded for testing)" patterns above (e.g. ruby/,
+# rust/) would otherwise swallow same-named fixture dirs. This negation is last
+# so it wins (git applies the last matching pattern).
+!tests/fixtures/boundary_ir/repos/
+!tests/fixtures/boundary_ir/repos/**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,23 @@
   - macOS timing-sensitive assertions; avoid overly tight thresholds
   - multiprocessing spawn/pickling differences on macOS
 
+## Changing the Boundary IR
+
+- The canonical Boundary IR is guarded by a determinism gate: per-language
+  golden snapshots (`tests/test_boundary_ir_golden_snapshots.py`), a non-empty
+  extraction guard, and a fail-closed grammar/runtime pin assertion
+  (`tests/test_boundary_ir_determinism.py`). Goldens cover all
+  `SUPPORTED_BOUNDARY_LANGUAGES` (C# excluded until its grammar ABI is fixed).
+- Any *intentional* Boundary IR change MUST be made by running
+  `python scripts/regenerate_boundary_goldens.py` on the pinned, ABI-paired
+  stack (tree_sitter 0.24 / tree-sitter-language-pack 0.9) and reviewing the
+  resulting golden diff in the PR. The script is idempotent — running it twice
+  produces no git diff.
+- Do NOT hand-edit goldens and do NOT bump `tree_sitter` or
+  `tree-sitter-language-pack` to make the gate pass: an unintended bump is
+  exactly what `test_grammar_runtime_pins_match` exists to catch. Unintended IR
+  changes fail loudly in CI by design.
+
 ## Notes
 
 - The `mypy` step currently reports many pre-existing issues and is non-blocking in CI.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### 🧪 Testing
+
+- **boundary-ir**: Determinism gate — extended golden Boundary IR coverage from
+  the 4 P0 languages to all 11 supported languages (python, javascript,
+  typescript, go, java, cpp, c, ruby, kotlin, swift, php; C# deliberately
+  excluded pending its grammar ABI fix). Added a non-empty-extraction guard
+  (`test_extraction_nonempty`) that fails loudly on the silent-`{}` /
+  ABI-mismatch failure mode, and a fail-closed grammar/runtime pin assertion
+  (`test_grammar_runtime_pins_match`) that trips on an unintended
+  tree_sitter / tree-sitter-language-pack bump. Added
+  `scripts/regenerate_boundary_goldens.py` as the sole sanctioned, idempotent
+  golden-regenerate path, and wired the new guards into `scripts/run_ci_smoke.py`.
+  Additive / guard-only — no extraction behavior changed.
+
 ## [3.1.0] - 2026-06-23
 
 ### 🐛 Bug Fixes

--- a/scripts/regenerate_boundary_goldens.py
+++ b/scripts/regenerate_boundary_goldens.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Regenerate the canonical Boundary IR golden snapshots.
+
+This is the ONE sanctioned way the committed goldens under
+``tests/fixtures/boundary_ir/golden/`` change. Any intentional Boundary IR
+change must be made here and reviewed as a golden diff in the PR; the
+determinism gate (``tests/test_boundary_ir_golden_snapshots.py`` +
+``tests/test_boundary_ir_determinism.py``) makes *unintended* changes fail
+loudly in CI.
+
+It MUST be run on the pinned, ABI-paired stack (tree_sitter 0.24 /
+tree-sitter-language-pack 0.9). Running it twice produces no git diff: output is
+byte-stable (``sort_keys`` + fixed indent), the volatile ``run.tool_version`` is
+normalized to a placeholder, and the IR's other volatile fields (timestamps,
+absolute roots) are already canonicalized by ``extract_boundary_ir`` /
+``normalize_ir_for_golden`` -- so goldens never embed an absolute path.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+# Run from the repository root so the repo-relative FIXTURE_ROOT / GOLDEN_ROOT
+# paths in tests.boundary_ir_conformance resolve, and import that module as the
+# single source of truth for the language list + normalization.
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from tests.boundary_ir_conformance import (  # noqa: E402
+    GOLDEN_ROOT,
+    SUPPORTED_BOUNDARY_LANGUAGES,
+    assert_grammar_runtime_pins,
+    extract_fixture_ir,
+    normalize_ir_for_golden,
+)
+
+
+def _golden_text(language: str) -> str:
+    """Return the byte-stable on-disk golden representation for a language."""
+    normalized = normalize_ir_for_golden(extract_fixture_ir(language))
+    # Mirror the committed goldens exactly: 2-space indent, sorted keys, trailing
+    # newline. sort_keys + fixed indent make the bytes deterministic across runs.
+    return json.dumps(normalized, indent=2, sort_keys=True) + "\n"
+
+
+def main() -> int:
+    # Fail closed before writing anything if the stack drifted off-pin -- we must
+    # never bake goldens on an unpinned grammar/runtime.
+    assert_grammar_runtime_pins()
+
+    golden_root = REPO_ROOT / GOLDEN_ROOT
+    golden_root.mkdir(parents=True, exist_ok=True)
+
+    print("Regenerating Boundary IR goldens (pinned stack):")
+    for language in SUPPORTED_BOUNDARY_LANGUAGES:
+        text = _golden_text(language)
+        path = golden_root / f"{language}.json"
+        existing = path.read_text(encoding="utf-8") if path.exists() else None
+        path.write_text(text, encoding="utf-8")
+        node_count = json.loads(text)["metrics"]["nodes_total"]
+        status = "unchanged" if existing == text else "updated"
+        print(f"- {language:<11} nodes={node_count:<3} {status}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_ci_smoke.py
+++ b/scripts/run_ci_smoke.py
@@ -24,6 +24,9 @@ CI_SMOKE_TESTS = [
     "tests/test_boundary_determinism.py",
     "tests/test_boundary_parity_view.py",
     "tests/test_boundary_ir_schema.py",
+    # Determinism gate: per-language golden non-empty guard + fail-closed
+    # grammar/runtime pin assertion (the silent-{} and ABI-drift failure modes).
+    "tests/test_boundary_ir_determinism.py",
 ]
 
 

--- a/tests/boundary_ir_conformance.py
+++ b/tests/boundary_ir_conformance.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from copy import deepcopy
+from importlib import metadata
 from pathlib import Path
 from typing import Any
 
@@ -13,9 +14,43 @@ from chunker.boundary.types import METRIC_KEYS, TIMING_KEYS, TOP_LEVEL_KEYS
 from chunker.parser import list_languages
 
 P0_BOUNDARY_LANGUAGES = ("python", "javascript", "typescript", "go")
+
+# The full set of languages the determinism gate holds to a committed golden +
+# non-empty-extraction guarantee. P0 is the richer semantic-parity contract
+# (manifest.json); this superset is the byte-level / grammar-health contract.
+#
+# c_sharp is DELIBERATELY EXCLUDED: tree-sitter-c-sharp ships an ABI-15 grammar
+# that is incompatible with the pinned tree_sitter 0.24 ABI, so it silently
+# emits {} (zero boundaries) rather than failing. It stays out of the gate until
+# its grammar ABI is fixed; see PR #77 (CppConfig + "C# blocked on grammar ABI,
+# deferred"). Excluding it here is a conscious, documented choice, not a silent
+# gap -- the non-empty guard below would otherwise (correctly) make it fail.
+SUPPORTED_BOUNDARY_LANGUAGES = (
+    "python",
+    "javascript",
+    "typescript",
+    "go",
+    "java",
+    "cpp",
+    "c",
+    "ruby",
+    "kotlin",
+    "swift",
+    "php",
+)
+
 FIXTURE_ROOT = Path("tests/fixtures/boundary_ir/repos")
 GOLDEN_ROOT = Path("tests/fixtures/boundary_ir/golden")
 GOLDEN_TOOL_VERSION = "<tool-version>"
+
+# Pinned grammar/runtime ranges. These MUST mirror pyproject.toml's dependency
+# pins (tree_sitter and tree-sitter-language-pack are ABI-paired; mixing 0.25.x
+# core with the 0.9.x pack's pre-compiled grammars breaks extraction). The pin
+# assertion below fails closed if an unintended transitive bump moves either
+# outside its range -- the exact failure mode that silently dropped Python
+# docstrings when tree_sitter drifted 0.24 -> 0.25.
+PINNED_TREE_SITTER = (("0.24", "0.25"), "tree_sitter")
+PINNED_LANGUAGE_PACK = (("0.9", "1.0"), "tree-sitter-language-pack")
 
 FILE_KEYS = (
     "id",
@@ -90,9 +125,9 @@ LOCATION_KEYS = ("byte_end", "byte_start", "end_line", "start_line")
 
 
 def fixture_path(language: str) -> Path:
-    """Return the repo-relative fixture root for a P0 language."""
-    if language not in P0_BOUNDARY_LANGUAGES:
-        msg = f"Unsupported P0 Boundary IR language: {language}"
+    """Return the repo-relative fixture root for a supported language."""
+    if language not in SUPPORTED_BOUNDARY_LANGUAGES:
+        msg = f"Unsupported Boundary IR language: {language}"
         raise ValueError(msg)
     return FIXTURE_ROOT / language
 
@@ -109,10 +144,59 @@ def skip_if_grammar_unavailable(language: str) -> None:
 
 
 def extract_fixture_ir(language: str) -> dict[str, Any]:
-    """Extract canonical Boundary IR from a P0 fixture repository."""
-    if language == "go":
-        skip_if_grammar_unavailable(language)
+    """Extract canonical Boundary IR from a supported fixture repository.
+
+    The determinism gate must NOT silently skip a supported language when its
+    grammar is missing -- a missing grammar is exactly the drift we want to fail
+    loudly on. So this calls extraction directly. ``skip_if_grammar_unavailable``
+    remains available for non-gate tests that opt into skipping.
+    """
     return extract_boundary_ir(fixture_path(language), language)
+
+
+def assert_extraction_nonempty(language: str) -> None:
+    """Fail loudly if a supported language extracts zero boundary nodes.
+
+    Guards the silent-``{}`` case: a grammar can be "available" yet emit nothing
+    (the C#/ABI-15 failure mode), which dict/golden equality alone would not
+    catch if the golden were also empty. Requiring >= 1 node makes a broken or
+    ABI-mismatched grammar a hard CI failure instead of a silent gap.
+    """
+    ir = extract_fixture_ir(language)
+    assert len(ir["nodes"]) >= 1, (
+        f"{language} extracted zero boundary nodes from its fixture repo; "
+        "the grammar is missing, ABI-mismatched, or emitting an empty IR. "
+        "This is the silent-empty failure mode the determinism gate exists to "
+        "catch -- investigate the grammar/runtime pairing, do not relax the gate."
+    )
+
+
+def _version_in_range(version: str, low: str, high: str) -> bool:
+    """Return whether ``low <= version < high`` using PEP 440 ordering."""
+    from packaging.version import Version
+
+    return Version(low) <= Version(version) < Version(high)
+
+
+def assert_grammar_runtime_pins() -> None:
+    """Fail closed if the installed grammar/runtime versions drift off-pin.
+
+    Reads the *installed* distribution versions and checks each against the
+    range pinned in pyproject.toml. An unintended transitive bump (e.g.
+    tree_sitter 0.24 -> 0.25, which breaks the ABI pairing with the pre-compiled
+    language-pack grammars) trips this guard rather than silently corrupting the
+    IR.
+    """
+    for (low, high), dist in (PINNED_TREE_SITTER, PINNED_LANGUAGE_PACK):
+        installed = metadata.version(dist)
+        assert _version_in_range(installed, low, high), (
+            f"{dist}=={installed} is outside the pinned range >={low},<{high}. "
+            "An unintended transitive bump tripped the determinism gate. "
+            "tree_sitter and tree-sitter-language-pack are ABI-paired; mixing "
+            "versions silently breaks Boundary IR extraction. Re-pin in "
+            "pyproject.toml deliberately and regenerate goldens, or roll back "
+            "the bump -- do not weaken this assertion."
+        )
 
 
 def fixture_boundary_json_bytes(language: str) -> bytes:

--- a/tests/fixtures/boundary_ir/golden/c.json
+++ b/tests/fixtures/boundary_ir/golden/c.json
@@ -1,0 +1,330 @@
+{
+  "diagnostics": [],
+  "edges": [
+    {
+      "candidates": [
+        "a87ce3a17ba52279eb8da7e44ac3a6252bace7fc"
+      ],
+      "id": "edge:06133e76e4713a45",
+      "location": {
+        "byte_end": null,
+        "byte_start": null,
+        "end_line": 9,
+        "start_line": 9
+      },
+      "metadata": {
+        "file": "widget.c",
+        "is_internal": true
+      },
+      "provenance": {
+        "enforcement_grade": "strict",
+        "resolution_mode": "strict",
+        "resolver": "extract_symbol_graph",
+        "source": "syntax"
+      },
+      "reference": "helper",
+      "resolution": "resolved",
+      "source": "4eb85efd6348631dbc4ef2ae94d21db85b8883df",
+      "target": "a87ce3a17ba52279eb8da7e44ac3a6252bace7fc",
+      "type": "calls"
+    },
+    {
+      "candidates": [
+        "a87ce3a17ba52279eb8da7e44ac3a6252bace7fc"
+      ],
+      "id": "edge:5aa50e8852e2469d",
+      "location": {
+        "byte_end": null,
+        "byte_start": null,
+        "end_line": 9,
+        "start_line": 9
+      },
+      "metadata": {
+        "file": "widget.c",
+        "is_internal": true
+      },
+      "provenance": {
+        "enforcement_grade": "strict",
+        "resolution_mode": "strict",
+        "resolver": "extract_symbol_graph",
+        "source": "syntax"
+      },
+      "reference": "helper",
+      "resolution": "resolved",
+      "source": "4eb85efd6348631dbc4ef2ae94d21db85b8883df",
+      "target": "a87ce3a17ba52279eb8da7e44ac3a6252bace7fc",
+      "type": "dependencies"
+    },
+    {
+      "candidates": [],
+      "id": "edge:ee0031636684cd7c",
+      "location": {
+        "byte_end": null,
+        "byte_start": null,
+        "end_line": 9,
+        "start_line": 9
+      },
+      "metadata": {
+        "file": "widget.c",
+        "is_internal": false
+      },
+      "provenance": {
+        "enforcement_grade": "strict",
+        "resolution_mode": "strict",
+        "resolver": "extract_symbol_graph",
+        "source": "syntax"
+      },
+      "reference": "w",
+      "resolution": "unresolved",
+      "source": "4eb85efd6348631dbc4ef2ae94d21db85b8883df",
+      "target": "w",
+      "type": "dependencies"
+    },
+    {
+      "candidates": [],
+      "id": "edge:61f45469e6be16d7",
+      "location": {
+        "byte_end": null,
+        "byte_start": null,
+        "end_line": 5,
+        "start_line": 5
+      },
+      "metadata": {
+        "file": "widget.c",
+        "is_internal": false
+      },
+      "provenance": {
+        "enforcement_grade": "strict",
+        "resolution_mode": "strict",
+        "resolver": "extract_symbol_graph",
+        "source": "syntax"
+      },
+      "reference": "value",
+      "resolution": "unresolved",
+      "source": "a87ce3a17ba52279eb8da7e44ac3a6252bace7fc",
+      "target": "value",
+      "type": "dependencies"
+    }
+  ],
+  "files": [
+    {
+      "content_hash": "sha1:a4fad01fb66dfef7e89de3a5909eada77129a7e8",
+      "diagnostics": [],
+      "id": "a2a9db15f65d218f03865ca3b80f19c0f0762001",
+      "language": "c",
+      "parser": "tree-sitter-c",
+      "path": "widget.c",
+      "status": "parsed"
+    }
+  ],
+  "metrics": {
+    "ambiguous_edges": 0,
+    "diagnostics_total": 0,
+    "edges_total": 4,
+    "failure_buckets": {},
+    "files_failed": 0,
+    "files_parsed": 1,
+    "files_processed": 1,
+    "files_skipped": 0,
+    "files_total": 1,
+    "graph_failures": 0,
+    "metadata_failures": 0,
+    "nodes_total": 4,
+    "parse_failures": 0,
+    "resolved_edges": 2,
+    "serialization_failures": 0,
+    "unresolved_edges": 2
+  },
+  "nodes": [
+    {
+      "definition_id": "12789ecfd69a4081dfac25664cbb786b84d77ca9",
+      "file_id": "a2a9db15f65d218f03865ca3b80f19c0f0762001",
+      "id": "12789ecfd69a4081dfac25664cbb786b84d77ca9",
+      "identity": {
+        "source": "definition_id",
+        "value": "12789ecfd69a4081dfac25664cbb786b84d77ca9"
+      },
+      "kind": "struct",
+      "language": "c",
+      "metadata": {
+        "dependencies": [],
+        "exports": [],
+        "imports": [],
+        "parent_symbol": null,
+        "semantic_text": "language: c\nfile: widget.c\nkind: struct\nsymbol: Widget\nqualified name: Widget\nsemantic path: widget.c::Widget\ncontent:\nstruct Widget {\n    int count;\n}"
+      },
+      "node_id": "a6c57df925decbbcde0a5a575a827ba69ee15301",
+      "parent": null,
+      "path": "widget.c",
+      "provenance": {
+        "extractor": "chunk_file",
+        "metadata": "retrieval"
+      },
+      "qualified_name": "Widget",
+      "relationships": [],
+      "semantic_path": "widget.c::Widget",
+      "signature": null,
+      "span": {
+        "byte_end": 32,
+        "byte_start": 0,
+        "end_line": 3,
+        "start_line": 1
+      },
+      "symbol": "Widget",
+      "symbol_id": "5c2d6d53853890133e91e9be4f2e3f84222ee130"
+    },
+    {
+      "definition_id": "4eb85efd6348631dbc4ef2ae94d21db85b8883df",
+      "file_id": "a2a9db15f65d218f03865ca3b80f19c0f0762001",
+      "id": "4eb85efd6348631dbc4ef2ae94d21db85b8883df",
+      "identity": {
+        "source": "definition_id",
+        "value": "4eb85efd6348631dbc4ef2ae94d21db85b8883df"
+      },
+      "kind": "function",
+      "language": "c",
+      "metadata": {
+        "dependencies": [
+          "helper",
+          "w"
+        ],
+        "exports": [
+          "render"
+        ],
+        "imports": [],
+        "parent_symbol": null,
+        "semantic_text": "language: c\nfile: widget.c\nkind: function\nsymbol: render\nqualified name: render\nsemantic path: widget.c::render\nsignature text: render(struct Widget *w) -> int\nexports: render\ndependencies: helper, w\ncontent:\nint render(struct Widget *w) {\n    return helper(w->count);\n}"
+      },
+      "node_id": "aef63f026c62933831cb7c1301d635b7318ade62",
+      "parent": null,
+      "path": "widget.c",
+      "provenance": {
+        "extractor": "chunk_file",
+        "metadata": "retrieval"
+      },
+      "qualified_name": "render",
+      "relationships": [
+        "edge:06133e76e4713a45",
+        "edge:5aa50e8852e2469d",
+        "edge:ee0031636684cd7c"
+      ],
+      "semantic_path": "widget.c::render",
+      "signature": "render(struct Widget *w) -> int",
+      "span": {
+        "byte_end": 145,
+        "byte_start": 84,
+        "end_line": 11,
+        "start_line": 9
+      },
+      "symbol": "render",
+      "symbol_id": "2d4e72009a66e84215f57e0681d6b7cc36aa3d61"
+    },
+    {
+      "definition_id": "6d3a751d52663e25620ebc79c4b9f5b1a33c9484",
+      "file_id": "a2a9db15f65d218f03865ca3b80f19c0f0762001",
+      "id": "6d3a751d52663e25620ebc79c4b9f5b1a33c9484",
+      "identity": {
+        "source": "definition_id",
+        "value": "6d3a751d52663e25620ebc79c4b9f5b1a33c9484"
+      },
+      "kind": "struct",
+      "language": "c",
+      "metadata": {
+        "dependencies": [],
+        "exports": [],
+        "imports": [],
+        "parent_symbol": null,
+        "semantic_text": "language: c\nfile: widget.c\nkind: struct\nsymbol: Widget\nqualified name: Widget\nsemantic path: widget.c::Widget\ncontent:\nstruct Widget"
+      },
+      "node_id": "0bf53fd6f48ccd08dc5a0715688da3e0dd5f9e7a",
+      "parent": "aef63f026c62933831cb7c1301d635b7318ade62",
+      "path": "widget.c",
+      "provenance": {
+        "extractor": "chunk_file",
+        "metadata": "retrieval"
+      },
+      "qualified_name": "Widget",
+      "relationships": [],
+      "semantic_path": "widget.c::Widget",
+      "signature": null,
+      "span": {
+        "byte_end": 108,
+        "byte_start": 95,
+        "end_line": 9,
+        "start_line": 9
+      },
+      "symbol": "Widget",
+      "symbol_id": "5c2d6d53853890133e91e9be4f2e3f84222ee130"
+    },
+    {
+      "definition_id": "a87ce3a17ba52279eb8da7e44ac3a6252bace7fc",
+      "file_id": "a2a9db15f65d218f03865ca3b80f19c0f0762001",
+      "id": "a87ce3a17ba52279eb8da7e44ac3a6252bace7fc",
+      "identity": {
+        "source": "definition_id",
+        "value": "a87ce3a17ba52279eb8da7e44ac3a6252bace7fc"
+      },
+      "kind": "function",
+      "language": "c",
+      "metadata": {
+        "dependencies": [
+          "value"
+        ],
+        "exports": [
+          "helper"
+        ],
+        "imports": [],
+        "parent_symbol": null,
+        "semantic_text": "language: c\nfile: widget.c\nkind: function\nsymbol: helper\nqualified name: helper\nsemantic path: widget.c::helper\nsignature text: helper(int value) -> int\nexports: helper\ndependencies: value\ncontent:\nint helper(int value) {\n    return value + 1;\n}"
+      },
+      "node_id": "d1dc095cafb83e27284d59c61d3ca0dd3b1f16f5",
+      "parent": null,
+      "path": "widget.c",
+      "provenance": {
+        "extractor": "chunk_file",
+        "metadata": "retrieval"
+      },
+      "qualified_name": "helper",
+      "relationships": [
+        "edge:61f45469e6be16d7"
+      ],
+      "semantic_path": "widget.c::helper",
+      "signature": "helper(int value) -> int",
+      "span": {
+        "byte_end": 82,
+        "byte_start": 35,
+        "end_line": 7,
+        "start_line": 5
+      },
+      "symbol": "helper",
+      "symbol_id": "63c7daeccff88b63e2360c8a9948d3a79da4dc9b"
+    }
+  ],
+  "run": {
+    "canonical": true,
+    "created_at": null,
+    "options": {
+      "fail_fast": false,
+      "include_retrieval_metadata": true,
+      "include_timings": false,
+      "language": "c",
+      "resolution_mode": "strict"
+    },
+    "root": "tests/fixtures/boundary_ir/repos/c",
+    "timings": {
+      "graph_assembly_ms": null,
+      "metadata_normalization_ms": null,
+      "parse_ms": null,
+      "resolution_ms": null,
+      "serialization_ms": null,
+      "total_ms": null
+    },
+    "tool": "treesitter-chunker",
+    "tool_version": "<tool-version>"
+  },
+  "schema_version": "2.0",
+  "source": {
+    "kind": "repository",
+    "path": "tests/fixtures/boundary_ir/repos/c"
+  }
+}

--- a/tests/fixtures/boundary_ir/golden/cpp.json
+++ b/tests/fixtures/boundary_ir/golden/cpp.json
@@ -1,0 +1,576 @@
+{
+  "diagnostics": [],
+  "edges": [
+    {
+      "candidates": [
+        "17e4949dedb2a95eb65cfc35732d2ce4ab551f34"
+      ],
+      "id": "edge:d77c93aab97e1e51",
+      "location": {
+        "byte_end": null,
+        "byte_start": null,
+        "end_line": 3,
+        "start_line": 3
+      },
+      "metadata": {
+        "file": "widget.cpp",
+        "is_internal": true
+      },
+      "provenance": {
+        "enforcement_grade": "strict",
+        "resolution_mode": "strict",
+        "resolver": "extract_symbol_graph",
+        "source": "syntax"
+      },
+      "reference": "helper",
+      "resolution": "resolved",
+      "source": "0bee8bd50c52e2babf8fe455f2c38454362c557c",
+      "target": "17e4949dedb2a95eb65cfc35732d2ce4ab551f34",
+      "type": "calls"
+    },
+    {
+      "candidates": [],
+      "id": "edge:d7cce1ee2b05c009",
+      "location": {
+        "byte_end": null,
+        "byte_start": null,
+        "end_line": 3,
+        "start_line": 3
+      },
+      "metadata": {
+        "file": "widget.cpp",
+        "is_internal": false
+      },
+      "provenance": {
+        "enforcement_grade": "strict",
+        "resolution_mode": "strict",
+        "resolver": "extract_symbol_graph",
+        "source": "syntax"
+      },
+      "reference": "count",
+      "resolution": "unresolved",
+      "source": "0bee8bd50c52e2babf8fe455f2c38454362c557c",
+      "target": "count",
+      "type": "dependencies"
+    },
+    {
+      "candidates": [],
+      "id": "edge:33a8c398872eb01f",
+      "location": {
+        "byte_end": null,
+        "byte_start": null,
+        "end_line": 11,
+        "start_line": 11
+      },
+      "metadata": {
+        "file": "widget.cpp",
+        "is_internal": false
+      },
+      "provenance": {
+        "enforcement_grade": "strict",
+        "resolution_mode": "strict",
+        "resolver": "extract_symbol_graph",
+        "source": "syntax"
+      },
+      "reference": "count",
+      "resolution": "unresolved",
+      "source": "17e4949dedb2a95eb65cfc35732d2ce4ab551f34",
+      "target": "count",
+      "type": "dependencies"
+    },
+    {
+      "candidates": [
+        "17e4949dedb2a95eb65cfc35732d2ce4ab551f34"
+      ],
+      "id": "edge:e48da697bb9ba911",
+      "location": {
+        "byte_end": null,
+        "byte_start": null,
+        "end_line": 7,
+        "start_line": 7
+      },
+      "metadata": {
+        "file": "widget.cpp",
+        "is_internal": true
+      },
+      "provenance": {
+        "enforcement_grade": "strict",
+        "resolution_mode": "strict",
+        "resolver": "extract_symbol_graph",
+        "source": "syntax"
+      },
+      "reference": "helper",
+      "resolution": "resolved",
+      "source": "1940d8e41e814151475d62410e23a8d4dbd2e6f4",
+      "target": "17e4949dedb2a95eb65cfc35732d2ce4ab551f34",
+      "type": "calls"
+    },
+    {
+      "candidates": [
+        "17e4949dedb2a95eb65cfc35732d2ce4ab551f34"
+      ],
+      "id": "edge:83c07923e9c0620c",
+      "location": {
+        "byte_end": null,
+        "byte_start": null,
+        "end_line": 7,
+        "start_line": 7
+      },
+      "metadata": {
+        "file": "widget.cpp",
+        "is_internal": true
+      },
+      "provenance": {
+        "enforcement_grade": "strict",
+        "resolution_mode": "strict",
+        "resolver": "extract_symbol_graph",
+        "source": "syntax"
+      },
+      "reference": "helper",
+      "resolution": "resolved",
+      "source": "1940d8e41e814151475d62410e23a8d4dbd2e6f4",
+      "target": "17e4949dedb2a95eb65cfc35732d2ce4ab551f34",
+      "type": "dependencies"
+    },
+    {
+      "candidates": [
+        "1940d8e41e814151475d62410e23a8d4dbd2e6f4"
+      ],
+      "id": "edge:5f022e7ba38eb674",
+      "location": {
+        "byte_end": null,
+        "byte_start": null,
+        "end_line": 16,
+        "start_line": 16
+      },
+      "metadata": {
+        "file": "widget.cpp",
+        "is_internal": true
+      },
+      "provenance": {
+        "enforcement_grade": "strict",
+        "resolution_mode": "strict",
+        "resolver": "extract_symbol_graph",
+        "source": "syntax"
+      },
+      "reference": "render",
+      "resolution": "resolved",
+      "source": "77ffc7c9aa54e26b250bccaec5b7fadb261f7443",
+      "target": "1940d8e41e814151475d62410e23a8d4dbd2e6f4",
+      "type": "calls"
+    },
+    {
+      "candidates": [],
+      "id": "edge:1bcd530da6dba7ca",
+      "location": {
+        "byte_end": null,
+        "byte_start": null,
+        "end_line": 16,
+        "start_line": 16
+      },
+      "metadata": {
+        "file": "widget.cpp",
+        "is_internal": false
+      },
+      "provenance": {
+        "enforcement_grade": "strict",
+        "resolution_mode": "strict",
+        "resolver": "extract_symbol_graph",
+        "source": "syntax"
+      },
+      "reference": "w",
+      "resolution": "unresolved",
+      "source": "77ffc7c9aa54e26b250bccaec5b7fadb261f7443",
+      "target": "w",
+      "type": "dependencies"
+    },
+    {
+      "candidates": [],
+      "id": "edge:5145d518d09d8298",
+      "location": {
+        "byte_end": null,
+        "byte_start": null,
+        "end_line": 1,
+        "start_line": 1
+      },
+      "metadata": {
+        "file": "widget.cpp",
+        "is_internal": false
+      },
+      "provenance": {
+        "enforcement_grade": "strict",
+        "resolution_mode": "strict",
+        "resolver": "extract_symbol_graph",
+        "source": "syntax"
+      },
+      "reference": "BLUE",
+      "resolution": "unresolved",
+      "source": "b451b3d7cc10d6f8ba7cbf9c5e1d3806171bedcb",
+      "target": "BLUE",
+      "type": "dependencies"
+    },
+    {
+      "candidates": [],
+      "id": "edge:4b6335434721ab4d",
+      "location": {
+        "byte_end": null,
+        "byte_start": null,
+        "end_line": 1,
+        "start_line": 1
+      },
+      "metadata": {
+        "file": "widget.cpp",
+        "is_internal": false
+      },
+      "provenance": {
+        "enforcement_grade": "strict",
+        "resolution_mode": "strict",
+        "resolver": "extract_symbol_graph",
+        "source": "syntax"
+      },
+      "reference": "GREEN",
+      "resolution": "unresolved",
+      "source": "b451b3d7cc10d6f8ba7cbf9c5e1d3806171bedcb",
+      "target": "GREEN",
+      "type": "dependencies"
+    },
+    {
+      "candidates": [],
+      "id": "edge:dfa93bcb31ac2641",
+      "location": {
+        "byte_end": null,
+        "byte_start": null,
+        "end_line": 1,
+        "start_line": 1
+      },
+      "metadata": {
+        "file": "widget.cpp",
+        "is_internal": false
+      },
+      "provenance": {
+        "enforcement_grade": "strict",
+        "resolution_mode": "strict",
+        "resolver": "extract_symbol_graph",
+        "source": "syntax"
+      },
+      "reference": "RED",
+      "resolution": "unresolved",
+      "source": "b451b3d7cc10d6f8ba7cbf9c5e1d3806171bedcb",
+      "target": "RED",
+      "type": "dependencies"
+    }
+  ],
+  "files": [
+    {
+      "content_hash": "sha1:76e6dfb603eb513cab2b91faac5a033bd8e043e9",
+      "diagnostics": [],
+      "id": "67f25e7957778dd68cfec96200eb22a8384e3f1a",
+      "language": "cpp",
+      "parser": "tree-sitter-cpp",
+      "path": "widget.cpp",
+      "status": "parsed"
+    }
+  ],
+  "metrics": {
+    "ambiguous_edges": 0,
+    "diagnostics_total": 0,
+    "edges_total": 10,
+    "failure_buckets": {},
+    "files_failed": 0,
+    "files_parsed": 1,
+    "files_processed": 1,
+    "files_skipped": 0,
+    "files_total": 1,
+    "graph_failures": 0,
+    "metadata_failures": 0,
+    "nodes_total": 6,
+    "parse_failures": 0,
+    "resolved_edges": 4,
+    "serialization_failures": 0,
+    "unresolved_edges": 6
+  },
+  "nodes": [
+    {
+      "definition_id": "0bee8bd50c52e2babf8fe455f2c38454362c557c",
+      "file_id": "67f25e7957778dd68cfec96200eb22a8384e3f1a",
+      "id": "0bee8bd50c52e2babf8fe455f2c38454362c557c",
+      "identity": {
+        "source": "definition_id",
+        "value": "0bee8bd50c52e2babf8fe455f2c38454362c557c"
+      },
+      "kind": "class",
+      "language": "cpp",
+      "metadata": {
+        "dependencies": [
+          "count"
+        ],
+        "exports": [],
+        "imports": [],
+        "parent_symbol": null,
+        "semantic_text": "language: cpp\nfile: widget.cpp\nkind: class\nsymbol: Widget\nqualified name: Widget\nsemantic path: widget.cpp::Widget\ndependencies: count\ncontent:\nclass Widget {\npublic:\n    int count;\n\n    int render() {\n        return helper();\n    }\n\n    int helper() {\n        return count + 1;\n    }\n}"
+      },
+      "node_id": "a9a9429aa3d99980f1bcfc555e9374cea145fa51",
+      "parent": null,
+      "path": "widget.cpp",
+      "provenance": {
+        "extractor": "chunk_file",
+        "metadata": "retrieval"
+      },
+      "qualified_name": "Widget",
+      "relationships": [
+        "edge:d77c93aab97e1e51",
+        "edge:d7cce1ee2b05c009"
+      ],
+      "semantic_path": "widget.cpp::Widget",
+      "signature": null,
+      "span": {
+        "byte_end": 176,
+        "byte_start": 34,
+        "end_line": 14,
+        "start_line": 3
+      },
+      "symbol": "Widget",
+      "symbol_id": "fbc3ea6be49ca30d519b73af2902922da168b56a"
+    },
+    {
+      "definition_id": "17e4949dedb2a95eb65cfc35732d2ce4ab551f34",
+      "file_id": "67f25e7957778dd68cfec96200eb22a8384e3f1a",
+      "id": "17e4949dedb2a95eb65cfc35732d2ce4ab551f34",
+      "identity": {
+        "source": "definition_id",
+        "value": "17e4949dedb2a95eb65cfc35732d2ce4ab551f34"
+      },
+      "kind": "method",
+      "language": "cpp",
+      "metadata": {
+        "dependencies": [
+          "count"
+        ],
+        "exports": [
+          "helper"
+        ],
+        "imports": [],
+        "parent_symbol": "Widget",
+        "semantic_text": "language: cpp\nfile: widget.cpp\nkind: method\nsymbol: helper\nqualified name: Widget.helper\nparent symbol: Widget\nsemantic path: widget.cpp::Widget.helper\nsignature text: helper() -> int\nexports: helper\ndependencies: count\ncontent:\nint helper() {\n        return count + 1;\n    }"
+      },
+      "node_id": "2d40a7f012e6b6a2948f925de0608895dbc3723b",
+      "parent": "a9a9429aa3d99980f1bcfc555e9374cea145fa51",
+      "path": "widget.cpp",
+      "provenance": {
+        "extractor": "chunk_file",
+        "metadata": "retrieval"
+      },
+      "qualified_name": "Widget.helper",
+      "relationships": [
+        "edge:33a8c398872eb01f"
+      ],
+      "semantic_path": "widget.cpp::Widget.helper",
+      "signature": "helper() -> int",
+      "span": {
+        "byte_end": 174,
+        "byte_start": 128,
+        "end_line": 13,
+        "start_line": 11
+      },
+      "symbol": "helper",
+      "symbol_id": "9db719cfc4046358a9a12cdf037430bf248fcd37"
+    },
+    {
+      "definition_id": "1940d8e41e814151475d62410e23a8d4dbd2e6f4",
+      "file_id": "67f25e7957778dd68cfec96200eb22a8384e3f1a",
+      "id": "1940d8e41e814151475d62410e23a8d4dbd2e6f4",
+      "identity": {
+        "source": "definition_id",
+        "value": "1940d8e41e814151475d62410e23a8d4dbd2e6f4"
+      },
+      "kind": "method",
+      "language": "cpp",
+      "metadata": {
+        "dependencies": [
+          "helper"
+        ],
+        "exports": [
+          "render"
+        ],
+        "imports": [],
+        "parent_symbol": "Widget",
+        "semantic_text": "language: cpp\nfile: widget.cpp\nkind: method\nsymbol: render\nqualified name: Widget.render\nparent symbol: Widget\nsemantic path: widget.cpp::Widget.render\nsignature text: render() -> int\nexports: render\ndependencies: helper\ncontent:\nint render() {\n        return helper();\n    }"
+      },
+      "node_id": "c518f075ee3e405cf2152b8f3145d4405161480c",
+      "parent": "a9a9429aa3d99980f1bcfc555e9374cea145fa51",
+      "path": "widget.cpp",
+      "provenance": {
+        "extractor": "chunk_file",
+        "metadata": "retrieval"
+      },
+      "qualified_name": "Widget.render",
+      "relationships": [
+        "edge:83c07923e9c0620c",
+        "edge:e48da697bb9ba911"
+      ],
+      "semantic_path": "widget.cpp::Widget.render",
+      "signature": "render() -> int",
+      "span": {
+        "byte_end": 122,
+        "byte_start": 77,
+        "end_line": 9,
+        "start_line": 7
+      },
+      "symbol": "render",
+      "symbol_id": "888aac2ad5943fd00ceca864617c157c6be447c0"
+    },
+    {
+      "definition_id": "77ffc7c9aa54e26b250bccaec5b7fadb261f7443",
+      "file_id": "67f25e7957778dd68cfec96200eb22a8384e3f1a",
+      "id": "77ffc7c9aa54e26b250bccaec5b7fadb261f7443",
+      "identity": {
+        "source": "definition_id",
+        "value": "77ffc7c9aa54e26b250bccaec5b7fadb261f7443"
+      },
+      "kind": "function",
+      "language": "cpp",
+      "metadata": {
+        "dependencies": [
+          "w"
+        ],
+        "exports": [
+          "run"
+        ],
+        "imports": [],
+        "parent_symbol": null,
+        "semantic_text": "language: cpp\nfile: widget.cpp\nkind: function\nsymbol: run\nqualified name: run\nsemantic path: widget.cpp::run\nsignature text: run() -> int\nexports: run\ndependencies: w\ncontent:\nint run() {\n    Widget w;\n    return w.render();\n}"
+      },
+      "node_id": "10eae52084f3843953e7c80d4777e72c3743e1ee",
+      "parent": null,
+      "path": "widget.cpp",
+      "provenance": {
+        "extractor": "chunk_file",
+        "metadata": "retrieval"
+      },
+      "qualified_name": "run",
+      "relationships": [
+        "edge:1bcd530da6dba7ca",
+        "edge:5f022e7ba38eb674"
+      ],
+      "semantic_path": "widget.cpp::run",
+      "signature": "run() -> int",
+      "span": {
+        "byte_end": 229,
+        "byte_start": 179,
+        "end_line": 19,
+        "start_line": 16
+      },
+      "symbol": "run",
+      "symbol_id": "4a160705e617f9c3bce3fd60e3b73beba87aab87"
+    },
+    {
+      "definition_id": "b0ab9cedfcbbb86fc2b2dbf38bfab78f67f0c016",
+      "file_id": "67f25e7957778dd68cfec96200eb22a8384e3f1a",
+      "id": "b0ab9cedfcbbb86fc2b2dbf38bfab78f67f0c016",
+      "identity": {
+        "source": "definition_id",
+        "value": "b0ab9cedfcbbb86fc2b2dbf38bfab78f67f0c016"
+      },
+      "kind": "field_declaration",
+      "language": "cpp",
+      "metadata": {
+        "dependencies": [],
+        "exports": [],
+        "imports": [],
+        "parent_symbol": "Widget",
+        "semantic_text": "language: cpp\nfile: widget.cpp\nkind: field_declaration\nsymbol: count\nqualified name: Widget.count\nparent symbol: Widget\nsemantic path: widget.cpp::Widget.count\ncontent:\nint count;"
+      },
+      "node_id": "f6897f384ba794499537c105a82b88824a557e67",
+      "parent": "a9a9429aa3d99980f1bcfc555e9374cea145fa51",
+      "path": "widget.cpp",
+      "provenance": {
+        "extractor": "chunk_file",
+        "metadata": "retrieval"
+      },
+      "qualified_name": "Widget.count",
+      "relationships": [],
+      "semantic_path": "widget.cpp::Widget.count",
+      "signature": null,
+      "span": {
+        "byte_end": 71,
+        "byte_start": 61,
+        "end_line": 5,
+        "start_line": 5
+      },
+      "symbol": "count",
+      "symbol_id": "506b329323ee67494eac4e6d74c0d4fa61ab0758"
+    },
+    {
+      "definition_id": "b451b3d7cc10d6f8ba7cbf9c5e1d3806171bedcb",
+      "file_id": "67f25e7957778dd68cfec96200eb22a8384e3f1a",
+      "id": "b451b3d7cc10d6f8ba7cbf9c5e1d3806171bedcb",
+      "identity": {
+        "source": "definition_id",
+        "value": "b451b3d7cc10d6f8ba7cbf9c5e1d3806171bedcb"
+      },
+      "kind": "enum",
+      "language": "cpp",
+      "metadata": {
+        "dependencies": [
+          "BLUE",
+          "GREEN",
+          "RED"
+        ],
+        "exports": [],
+        "imports": [],
+        "parent_symbol": null,
+        "semantic_text": "language: cpp\nfile: widget.cpp\nkind: enum\nsymbol: Color\nqualified name: Color\nsemantic path: widget.cpp::Color\ndependencies: BLUE, GREEN, RED\ncontent:\nenum Color { RED, GREEN, BLUE }"
+      },
+      "node_id": "39af059406596657096a3bd07dcd4caf6e10ca0e",
+      "parent": null,
+      "path": "widget.cpp",
+      "provenance": {
+        "extractor": "chunk_file",
+        "metadata": "retrieval"
+      },
+      "qualified_name": "Color",
+      "relationships": [
+        "edge:4b6335434721ab4d",
+        "edge:5145d518d09d8298",
+        "edge:dfa93bcb31ac2641"
+      ],
+      "semantic_path": "widget.cpp::Color",
+      "signature": null,
+      "span": {
+        "byte_end": 31,
+        "byte_start": 0,
+        "end_line": 1,
+        "start_line": 1
+      },
+      "symbol": "Color",
+      "symbol_id": "adc2666706081f9110cdafa953a1a01c2bc55c7b"
+    }
+  ],
+  "run": {
+    "canonical": true,
+    "created_at": null,
+    "options": {
+      "fail_fast": false,
+      "include_retrieval_metadata": true,
+      "include_timings": false,
+      "language": "cpp",
+      "resolution_mode": "strict"
+    },
+    "root": "tests/fixtures/boundary_ir/repos/cpp",
+    "timings": {
+      "graph_assembly_ms": null,
+      "metadata_normalization_ms": null,
+      "parse_ms": null,
+      "resolution_ms": null,
+      "serialization_ms": null,
+      "total_ms": null
+    },
+    "tool": "treesitter-chunker",
+    "tool_version": "<tool-version>"
+  },
+  "schema_version": "2.0",
+  "source": {
+    "kind": "repository",
+    "path": "tests/fixtures/boundary_ir/repos/cpp"
+  }
+}

--- a/tests/fixtures/boundary_ir/golden/java.json
+++ b/tests/fixtures/boundary_ir/golden/java.json
@@ -1,0 +1,284 @@
+{
+  "diagnostics": [],
+  "edges": [],
+  "files": [
+    {
+      "content_hash": "sha1:167fc645d16a6f2062bb5aafb05cdec9fc69e7b1",
+      "diagnostics": [],
+      "id": "5334ee93a069e7868ee9fe23c115d3437668d078",
+      "language": "java",
+      "parser": "tree-sitter-java",
+      "path": "Widget.java",
+      "status": "parsed"
+    }
+  ],
+  "metrics": {
+    "ambiguous_edges": 0,
+    "diagnostics_total": 0,
+    "edges_total": 0,
+    "failure_buckets": {},
+    "files_failed": 0,
+    "files_parsed": 1,
+    "files_processed": 1,
+    "files_skipped": 0,
+    "files_total": 1,
+    "graph_failures": 0,
+    "metadata_failures": 0,
+    "nodes_total": 6,
+    "parse_failures": 0,
+    "resolved_edges": 0,
+    "serialization_failures": 0,
+    "unresolved_edges": 0
+  },
+  "nodes": [
+    {
+      "definition_id": "405d4f0f7e490f29227880779051d107180fd922",
+      "file_id": "5334ee93a069e7868ee9fe23c115d3437668d078",
+      "id": "405d4f0f7e490f29227880779051d107180fd922",
+      "identity": {
+        "source": "definition_id",
+        "value": "405d4f0f7e490f29227880779051d107180fd922"
+      },
+      "kind": "field_declaration",
+      "language": "java",
+      "metadata": {
+        "dependencies": [],
+        "exports": [],
+        "imports": [],
+        "parent_symbol": "Widget",
+        "semantic_text": "language: java\nfile: Widget.java\nkind: field_declaration\nsymbol: count\nqualified name: Widget.count\nparent symbol: Widget\nsemantic path: Widget.java::Widget.count\ncontent:\nprivate int count;"
+      },
+      "node_id": "ba4dc48d6151421e3bd9b9a4ac03250f0e42e152",
+      "parent": "7283643a995241b5bda153a2f07868e7ebaf78fb",
+      "path": "Widget.java",
+      "provenance": {
+        "extractor": "chunk_file",
+        "metadata": "retrieval"
+      },
+      "qualified_name": "Widget.count",
+      "relationships": [],
+      "semantic_path": "Widget.java::Widget.count",
+      "signature": null,
+      "span": {
+        "byte_end": 58,
+        "byte_start": 40,
+        "end_line": 4,
+        "start_line": 4
+      },
+      "symbol": "count",
+      "symbol_id": "6b119c1f5dab633df4cbab401efe28a12c2f1e38"
+    },
+    {
+      "definition_id": "6290d565e086df515c2fdf2b7c2a8e5dacda8433",
+      "file_id": "5334ee93a069e7868ee9fe23c115d3437668d078",
+      "id": "6290d565e086df515c2fdf2b7c2a8e5dacda8433",
+      "identity": {
+        "source": "definition_id",
+        "value": "6290d565e086df515c2fdf2b7c2a8e5dacda8433"
+      },
+      "kind": "class",
+      "language": "java",
+      "metadata": {
+        "dependencies": [],
+        "exports": [],
+        "imports": [],
+        "parent_symbol": null,
+        "semantic_text": "language: java\nfile: Widget.java\nkind: class\nsymbol: Widget\nqualified name: Widget\nsemantic path: Widget.java::Widget\ncontent:\npublic class Widget {\n    private int count;\n\n    public Widget(int count) {\n        this.count = count;\n    }\n\n    public int render() {\n        return helper(count);\n    }\n\n    private int helper(int value) {\n        return value + 1;\n    }\n}"
+      },
+      "node_id": "7283643a995241b5bda153a2f07868e7ebaf78fb",
+      "parent": null,
+      "path": "Widget.java",
+      "provenance": {
+        "extractor": "chunk_file",
+        "metadata": "retrieval"
+      },
+      "qualified_name": "Widget",
+      "relationships": [],
+      "semantic_path": "Widget.java::Widget",
+      "signature": null,
+      "span": {
+        "byte_end": 258,
+        "byte_start": 14,
+        "end_line": 17,
+        "start_line": 3
+      },
+      "symbol": "Widget",
+      "symbol_id": "81eba169f938c21200a87c81593c1c32cfbd33c4"
+    },
+    {
+      "definition_id": "6f969d2ee6ac785243cfe7fda679a1b8f26cd94a",
+      "file_id": "5334ee93a069e7868ee9fe23c115d3437668d078",
+      "id": "6f969d2ee6ac785243cfe7fda679a1b8f26cd94a",
+      "identity": {
+        "source": "definition_id",
+        "value": "6f969d2ee6ac785243cfe7fda679a1b8f26cd94a"
+      },
+      "kind": "method",
+      "language": "java",
+      "metadata": {
+        "dependencies": [],
+        "exports": [],
+        "imports": [],
+        "parent_symbol": "Widget",
+        "semantic_text": "language: java\nfile: Widget.java\nkind: method\nsymbol: render\nqualified name: Widget.render\nparent symbol: Widget\nsemantic path: Widget.java::Widget.render\ncontent:\npublic int render() {\n        return helper(count);\n    }"
+      },
+      "node_id": "c76ce267c33547067ab1449fee4ac170b5897e27",
+      "parent": "7283643a995241b5bda153a2f07868e7ebaf78fb",
+      "path": "Widget.java",
+      "provenance": {
+        "extractor": "chunk_file",
+        "metadata": "retrieval"
+      },
+      "qualified_name": "Widget.render",
+      "relationships": [],
+      "semantic_path": "Widget.java::Widget.render",
+      "signature": null,
+      "span": {
+        "byte_end": 187,
+        "byte_start": 130,
+        "end_line": 12,
+        "start_line": 10
+      },
+      "symbol": "render",
+      "symbol_id": "c61d5bc44b29ed125e71a28d047c82c0dd025ba2"
+    },
+    {
+      "definition_id": "8bdd0ff0349aeca8d6605680598090eaa5c5fa90",
+      "file_id": "5334ee93a069e7868ee9fe23c115d3437668d078",
+      "id": "8bdd0ff0349aeca8d6605680598090eaa5c5fa90",
+      "identity": {
+        "source": "definition_id",
+        "value": "8bdd0ff0349aeca8d6605680598090eaa5c5fa90"
+      },
+      "kind": "method",
+      "language": "java",
+      "metadata": {
+        "dependencies": [],
+        "exports": [],
+        "imports": [],
+        "parent_symbol": "Widget",
+        "semantic_text": "language: java\nfile: Widget.java\nkind: method\nsymbol: helper\nqualified name: Widget.helper\nparent symbol: Widget\nsemantic path: Widget.java::Widget.helper\ncontent:\nprivate int helper(int value) {\n        return value + 1;\n    }"
+      },
+      "node_id": "6ffeb6db764f5be488dbe7a872f38f1a3cfc82e0",
+      "parent": "7283643a995241b5bda153a2f07868e7ebaf78fb",
+      "path": "Widget.java",
+      "provenance": {
+        "extractor": "chunk_file",
+        "metadata": "retrieval"
+      },
+      "qualified_name": "Widget.helper",
+      "relationships": [],
+      "semantic_path": "Widget.java::Widget.helper",
+      "signature": null,
+      "span": {
+        "byte_end": 256,
+        "byte_start": 193,
+        "end_line": 16,
+        "start_line": 14
+      },
+      "symbol": "helper",
+      "symbol_id": "34139ccbae995ed04c1c338f4eb70c4c3e8cfe56"
+    },
+    {
+      "definition_id": "97eec646cd212e90887ff5e34b05fcf76b638122",
+      "file_id": "5334ee93a069e7868ee9fe23c115d3437668d078",
+      "id": "97eec646cd212e90887ff5e34b05fcf76b638122",
+      "identity": {
+        "source": "definition_id",
+        "value": "97eec646cd212e90887ff5e34b05fcf76b638122"
+      },
+      "kind": "constructor",
+      "language": "java",
+      "metadata": {
+        "dependencies": [],
+        "exports": [],
+        "imports": [],
+        "parent_symbol": "Widget",
+        "semantic_text": "language: java\nfile: Widget.java\nkind: constructor\nsymbol: Widget\nqualified name: Widget.Widget\nparent symbol: Widget\nsemantic path: Widget.java::Widget.Widget\ncontent:\npublic Widget(int count) {\n        this.count = count;\n    }"
+      },
+      "node_id": "a65f0ee8f4baf57fe99a8294d02120ac241ea650",
+      "parent": "7283643a995241b5bda153a2f07868e7ebaf78fb",
+      "path": "Widget.java",
+      "provenance": {
+        "extractor": "chunk_file",
+        "metadata": "retrieval"
+      },
+      "qualified_name": "Widget.Widget",
+      "relationships": [],
+      "semantic_path": "Widget.java::Widget.Widget",
+      "signature": null,
+      "span": {
+        "byte_end": 124,
+        "byte_start": 64,
+        "end_line": 8,
+        "start_line": 6
+      },
+      "symbol": "Widget",
+      "symbol_id": "81eba169f938c21200a87c81593c1c32cfbd33c4"
+    },
+    {
+      "definition_id": "9adcc537e275bcb236589b0553fc86ad79784377",
+      "file_id": "5334ee93a069e7868ee9fe23c115d3437668d078",
+      "id": "9adcc537e275bcb236589b0553fc86ad79784377",
+      "identity": {
+        "source": "definition_id",
+        "value": "9adcc537e275bcb236589b0553fc86ad79784377"
+      },
+      "kind": "enum",
+      "language": "java",
+      "metadata": {
+        "dependencies": [],
+        "exports": [],
+        "imports": [],
+        "parent_symbol": null,
+        "semantic_text": "language: java\nfile: Widget.java\nkind: enum\nsymbol: Color\nqualified name: Color\nsemantic path: Widget.java::Color\ncontent:\nenum Color {\n    RED,\n    GREEN,\n    BLUE\n}"
+      },
+      "node_id": "5c1ffad1d9a5572b6c47f08abad6a96de2bae1b3",
+      "parent": null,
+      "path": "Widget.java",
+      "provenance": {
+        "extractor": "chunk_file",
+        "metadata": "retrieval"
+      },
+      "qualified_name": "Color",
+      "relationships": [],
+      "semantic_path": "Widget.java::Color",
+      "signature": null,
+      "span": {
+        "byte_end": 303,
+        "byte_start": 260,
+        "end_line": 23,
+        "start_line": 19
+      },
+      "symbol": "Color",
+      "symbol_id": "a742917abae85d2f15c718b40ee3d63d52109f37"
+    }
+  ],
+  "run": {
+    "canonical": true,
+    "created_at": null,
+    "options": {
+      "fail_fast": false,
+      "include_retrieval_metadata": true,
+      "include_timings": false,
+      "language": "java",
+      "resolution_mode": "strict"
+    },
+    "root": "tests/fixtures/boundary_ir/repos/java",
+    "timings": {
+      "graph_assembly_ms": null,
+      "metadata_normalization_ms": null,
+      "parse_ms": null,
+      "resolution_ms": null,
+      "serialization_ms": null,
+      "total_ms": null
+    },
+    "tool": "treesitter-chunker",
+    "tool_version": "<tool-version>"
+  },
+  "schema_version": "2.0",
+  "source": {
+    "kind": "repository",
+    "path": "tests/fixtures/boundary_ir/repos/java"
+  }
+}

--- a/tests/fixtures/boundary_ir/golden/kotlin.json
+++ b/tests/fixtures/boundary_ir/golden/kotlin.json
@@ -1,0 +1,210 @@
+{
+  "diagnostics": [],
+  "edges": [],
+  "files": [
+    {
+      "content_hash": "sha1:da21dc4f63570260f626a07c6207178ebf3416fc",
+      "diagnostics": [],
+      "id": "1aae6d0cbd7a6568c104c279e72116a4f6feb374",
+      "language": "kotlin",
+      "parser": "tree-sitter-kotlin",
+      "path": "Widget.kt",
+      "status": "parsed"
+    }
+  ],
+  "metrics": {
+    "ambiguous_edges": 0,
+    "diagnostics_total": 0,
+    "edges_total": 0,
+    "failure_buckets": {},
+    "files_failed": 0,
+    "files_parsed": 1,
+    "files_processed": 1,
+    "files_skipped": 0,
+    "files_total": 1,
+    "graph_failures": 0,
+    "metadata_failures": 0,
+    "nodes_total": 4,
+    "parse_failures": 0,
+    "resolved_edges": 0,
+    "serialization_failures": 0,
+    "unresolved_edges": 0
+  },
+  "nodes": [
+    {
+      "definition_id": "4c571ad7d112f80b2a26511e73a9018a715d756f",
+      "file_id": "1aae6d0cbd7a6568c104c279e72116a4f6feb374",
+      "id": "4c571ad7d112f80b2a26511e73a9018a715d756f",
+      "identity": {
+        "source": "definition_id",
+        "value": "4c571ad7d112f80b2a26511e73a9018a715d756f"
+      },
+      "kind": "method",
+      "language": "kotlin",
+      "metadata": {
+        "dependencies": [],
+        "exports": [],
+        "imports": [],
+        "parent_symbol": null,
+        "semantic_text": "language: kotlin\nfile: Widget.kt\nkind: method\nsymbol: class_declaration\nqualified name: class_declaration\nsemantic path: Widget.kt::class_declaration\ncontent:\nfun render(): Int {\n        return helper(count)\n    }"
+      },
+      "node_id": "d36caa45ccfa1294f8ee678fd1e26b6a2b131028",
+      "parent": "e5bfe8bb686fd1d7aacaa54934433170b693988c",
+      "path": "Widget.kt",
+      "provenance": {
+        "extractor": "chunk_file",
+        "metadata": "retrieval"
+      },
+      "qualified_name": "class_declaration",
+      "relationships": [],
+      "semantic_path": "Widget.kt::class_declaration",
+      "signature": null,
+      "span": {
+        "byte_end": 102,
+        "byte_start": 48,
+        "end_line": 6,
+        "start_line": 4
+      },
+      "symbol": "class_declaration",
+      "symbol_id": "51e225fc38da234fc2fb3cc3331f92ac73cc75ed"
+    },
+    {
+      "definition_id": "cc0a6e60f1c7360be23cdadf259175c7a60625a6",
+      "file_id": "1aae6d0cbd7a6568c104c279e72116a4f6feb374",
+      "id": "cc0a6e60f1c7360be23cdadf259175c7a60625a6",
+      "identity": {
+        "source": "definition_id",
+        "value": "cc0a6e60f1c7360be23cdadf259175c7a60625a6"
+      },
+      "kind": "method",
+      "language": "kotlin",
+      "metadata": {
+        "dependencies": [],
+        "exports": [],
+        "imports": [],
+        "parent_symbol": null,
+        "semantic_text": "language: kotlin\nfile: Widget.kt\nkind: method\nsymbol: class_declaration\nqualified name: class_declaration\nsemantic path: Widget.kt::class_declaration\ncontent:\nfun helper(value: Int): Int {\n        return value + 1\n    }"
+      },
+      "node_id": "8c0124bef7d88ec5b0bc960b8d8610e1bfd06633",
+      "parent": "e5bfe8bb686fd1d7aacaa54934433170b693988c",
+      "path": "Widget.kt",
+      "provenance": {
+        "extractor": "chunk_file",
+        "metadata": "retrieval"
+      },
+      "qualified_name": "class_declaration",
+      "relationships": [],
+      "semantic_path": "Widget.kt::class_declaration",
+      "signature": null,
+      "span": {
+        "byte_end": 168,
+        "byte_start": 108,
+        "end_line": 10,
+        "start_line": 8
+      },
+      "symbol": "class_declaration",
+      "symbol_id": "51e225fc38da234fc2fb3cc3331f92ac73cc75ed"
+    },
+    {
+      "definition_id": "f16906df0adc4ed69aa8f61caff4bde67ad2e62e",
+      "file_id": "1aae6d0cbd7a6568c104c279e72116a4f6feb374",
+      "id": "f16906df0adc4ed69aa8f61caff4bde67ad2e62e",
+      "identity": {
+        "source": "definition_id",
+        "value": "f16906df0adc4ed69aa8f61caff4bde67ad2e62e"
+      },
+      "kind": "function",
+      "language": "kotlin",
+      "metadata": {
+        "dependencies": [],
+        "exports": [],
+        "imports": [],
+        "parent_symbol": null,
+        "semantic_text": "language: kotlin\nfile: Widget.kt\nkind: function\nsemantic path: Widget.kt\ncontent:\nfun run(): Int {\n    return Widget(1).render()\n}"
+      },
+      "node_id": "d0666efc976e2f9010a631f34b32c737cbaa58b1",
+      "parent": null,
+      "path": "Widget.kt",
+      "provenance": {
+        "extractor": "chunk_file",
+        "metadata": "retrieval"
+      },
+      "qualified_name": null,
+      "relationships": [],
+      "semantic_path": "Widget.kt",
+      "signature": null,
+      "span": {
+        "byte_end": 220,
+        "byte_start": 172,
+        "end_line": 15,
+        "start_line": 13
+      },
+      "symbol": null,
+      "symbol_id": null
+    },
+    {
+      "definition_id": "fa65b306cfa8a20c256934715ee62d31f0acef19",
+      "file_id": "1aae6d0cbd7a6568c104c279e72116a4f6feb374",
+      "id": "fa65b306cfa8a20c256934715ee62d31f0acef19",
+      "identity": {
+        "source": "definition_id",
+        "value": "fa65b306cfa8a20c256934715ee62d31f0acef19"
+      },
+      "kind": "class",
+      "language": "kotlin",
+      "metadata": {
+        "dependencies": [],
+        "exports": [],
+        "imports": [],
+        "parent_symbol": null,
+        "semantic_text": "language: kotlin\nfile: Widget.kt\nkind: class\nsemantic path: Widget.kt\ncontent:\nclass Widget(val count: Int) {\n    fun render(): Int {\n        return helper(count)\n    }\n\n    fun helper(value: Int): Int {\n        return value + 1\n    }\n}"
+      },
+      "node_id": "e5bfe8bb686fd1d7aacaa54934433170b693988c",
+      "parent": null,
+      "path": "Widget.kt",
+      "provenance": {
+        "extractor": "chunk_file",
+        "metadata": "retrieval"
+      },
+      "qualified_name": null,
+      "relationships": [],
+      "semantic_path": "Widget.kt",
+      "signature": null,
+      "span": {
+        "byte_end": 170,
+        "byte_start": 13,
+        "end_line": 11,
+        "start_line": 3
+      },
+      "symbol": null,
+      "symbol_id": null
+    }
+  ],
+  "run": {
+    "canonical": true,
+    "created_at": null,
+    "options": {
+      "fail_fast": false,
+      "include_retrieval_metadata": true,
+      "include_timings": false,
+      "language": "kotlin",
+      "resolution_mode": "strict"
+    },
+    "root": "tests/fixtures/boundary_ir/repos/kotlin",
+    "timings": {
+      "graph_assembly_ms": null,
+      "metadata_normalization_ms": null,
+      "parse_ms": null,
+      "resolution_ms": null,
+      "serialization_ms": null,
+      "total_ms": null
+    },
+    "tool": "treesitter-chunker",
+    "tool_version": "<tool-version>"
+  },
+  "schema_version": "2.0",
+  "source": {
+    "kind": "repository",
+    "path": "tests/fixtures/boundary_ir/repos/kotlin"
+  }
+}

--- a/tests/fixtures/boundary_ir/golden/php.json
+++ b/tests/fixtures/boundary_ir/golden/php.json
@@ -1,0 +1,247 @@
+{
+  "diagnostics": [],
+  "edges": [],
+  "files": [
+    {
+      "content_hash": "sha1:25523405164fab24faaf0f1c0988d81ba19aa63c",
+      "diagnostics": [],
+      "id": "112db18be7c9bd026dfbccd2fa972bca59498e3d",
+      "language": "php",
+      "parser": "tree-sitter-php",
+      "path": "widget.php",
+      "status": "parsed"
+    }
+  ],
+  "metrics": {
+    "ambiguous_edges": 0,
+    "diagnostics_total": 0,
+    "edges_total": 0,
+    "failure_buckets": {},
+    "files_failed": 0,
+    "files_parsed": 1,
+    "files_processed": 1,
+    "files_skipped": 0,
+    "files_total": 1,
+    "graph_failures": 0,
+    "metadata_failures": 0,
+    "nodes_total": 5,
+    "parse_failures": 0,
+    "resolved_edges": 0,
+    "serialization_failures": 0,
+    "unresolved_edges": 0
+  },
+  "nodes": [
+    {
+      "definition_id": "04614565298c6fe1e886659291a158408d5da191",
+      "file_id": "112db18be7c9bd026dfbccd2fa972bca59498e3d",
+      "id": "04614565298c6fe1e886659291a158408d5da191",
+      "identity": {
+        "source": "definition_id",
+        "value": "04614565298c6fe1e886659291a158408d5da191"
+      },
+      "kind": "method",
+      "language": "php",
+      "metadata": {
+        "dependencies": [],
+        "exports": [],
+        "imports": [],
+        "parent_symbol": "Widget",
+        "semantic_text": "language: php\nfile: widget.php\nkind: method\nsymbol: helper\nqualified name: Widget.helper\nparent symbol: Widget\nsemantic path: widget.php::Widget.helper\ncontent:\npublic function helper($value)\n    {\n        return $value + 1;\n    }"
+      },
+      "node_id": "b7ef83705199e5c1f8eed0a4b78fd496c4565b0a",
+      "parent": "b52b300aeacf6ceff1dcaf8fa60eb96eb74ef17a",
+      "path": "widget.php",
+      "provenance": {
+        "extractor": "chunk_file",
+        "metadata": "retrieval"
+      },
+      "qualified_name": "Widget.helper",
+      "relationships": [],
+      "semantic_path": "widget.php::Widget.helper",
+      "signature": null,
+      "span": {
+        "byte_end": 205,
+        "byte_start": 136,
+        "end_line": 15,
+        "start_line": 12
+      },
+      "symbol": "helper",
+      "symbol_id": "77453ae226226d45d2d25f93fd61db78a646f92c"
+    },
+    {
+      "definition_id": "104cb1570c65a81493be515cddcdcfaaf7ebfcdd",
+      "file_id": "112db18be7c9bd026dfbccd2fa972bca59498e3d",
+      "id": "104cb1570c65a81493be515cddcdcfaaf7ebfcdd",
+      "identity": {
+        "source": "definition_id",
+        "value": "104cb1570c65a81493be515cddcdcfaaf7ebfcdd"
+      },
+      "kind": "property_declaration",
+      "language": "php",
+      "metadata": {
+        "dependencies": [],
+        "exports": [],
+        "imports": [],
+        "parent_symbol": null,
+        "semantic_text": "language: php\nfile: widget.php\nkind: property_declaration\nsymbol: Widget\nqualified name: Widget\nsemantic path: widget.php::Widget\ncontent:\npublic $count = 0;"
+      },
+      "node_id": "ea1fb64f623a4414bf2046a82b4178f85f6afa4e",
+      "parent": "b52b300aeacf6ceff1dcaf8fa60eb96eb74ef17a",
+      "path": "widget.php",
+      "provenance": {
+        "extractor": "chunk_file",
+        "metadata": "retrieval"
+      },
+      "qualified_name": "Widget",
+      "relationships": [],
+      "semantic_path": "widget.php::Widget",
+      "signature": null,
+      "span": {
+        "byte_end": 44,
+        "byte_start": 26,
+        "end_line": 5,
+        "start_line": 5
+      },
+      "symbol": "Widget",
+      "symbol_id": "168a2d6de0bdba0de2055e13fc186578de1436fa"
+    },
+    {
+      "definition_id": "1ca03e9770c5f211ea36a4a98ba33cf9c93136bb",
+      "file_id": "112db18be7c9bd026dfbccd2fa972bca59498e3d",
+      "id": "1ca03e9770c5f211ea36a4a98ba33cf9c93136bb",
+      "identity": {
+        "source": "definition_id",
+        "value": "1ca03e9770c5f211ea36a4a98ba33cf9c93136bb"
+      },
+      "kind": "function",
+      "language": "php",
+      "metadata": {
+        "dependencies": [],
+        "exports": [],
+        "imports": [],
+        "parent_symbol": null,
+        "semantic_text": "language: php\nfile: widget.php\nkind: function\nsymbol: run\nqualified name: run\nsemantic path: widget.php::run\ncontent:\nfunction run()\n{\n    $w = new Widget();\n    return $w->render();\n}"
+      },
+      "node_id": "f0882a64384472e5bc80036eb5de9ee3adfa1bbb",
+      "parent": null,
+      "path": "widget.php",
+      "provenance": {
+        "extractor": "chunk_file",
+        "metadata": "retrieval"
+      },
+      "qualified_name": "run",
+      "relationships": [],
+      "semantic_path": "widget.php::run",
+      "signature": null,
+      "span": {
+        "byte_end": 275,
+        "byte_start": 209,
+        "end_line": 22,
+        "start_line": 18
+      },
+      "symbol": "run",
+      "symbol_id": "d97842f1cf5648047761fbd5bfa96e95c1c9e1dd"
+    },
+    {
+      "definition_id": "5061122c3f58a71696ac6e4b9c959a11292b39c7",
+      "file_id": "112db18be7c9bd026dfbccd2fa972bca59498e3d",
+      "id": "5061122c3f58a71696ac6e4b9c959a11292b39c7",
+      "identity": {
+        "source": "definition_id",
+        "value": "5061122c3f58a71696ac6e4b9c959a11292b39c7"
+      },
+      "kind": "class",
+      "language": "php",
+      "metadata": {
+        "dependencies": [],
+        "exports": [],
+        "imports": [],
+        "parent_symbol": null,
+        "semantic_text": "language: php\nfile: widget.php\nkind: class\nsymbol: Widget\nqualified name: Widget\nsemantic path: widget.php::Widget\ncontent:\nclass Widget\n{\n    public $count = 0;\n\n    public function render()\n    {\n        return $this->helper($this->count);\n    }\n\n    public function helper($value)\n    {\n        return $value + 1;\n    }\n}"
+      },
+      "node_id": "b52b300aeacf6ceff1dcaf8fa60eb96eb74ef17a",
+      "parent": null,
+      "path": "widget.php",
+      "provenance": {
+        "extractor": "chunk_file",
+        "metadata": "retrieval"
+      },
+      "qualified_name": "Widget",
+      "relationships": [],
+      "semantic_path": "widget.php::Widget",
+      "signature": null,
+      "span": {
+        "byte_end": 207,
+        "byte_start": 7,
+        "end_line": 16,
+        "start_line": 3
+      },
+      "symbol": "Widget",
+      "symbol_id": "168a2d6de0bdba0de2055e13fc186578de1436fa"
+    },
+    {
+      "definition_id": "9fad269433dd9bbf7e738a1311736b939ef428b6",
+      "file_id": "112db18be7c9bd026dfbccd2fa972bca59498e3d",
+      "id": "9fad269433dd9bbf7e738a1311736b939ef428b6",
+      "identity": {
+        "source": "definition_id",
+        "value": "9fad269433dd9bbf7e738a1311736b939ef428b6"
+      },
+      "kind": "method",
+      "language": "php",
+      "metadata": {
+        "dependencies": [],
+        "exports": [],
+        "imports": [],
+        "parent_symbol": "Widget",
+        "semantic_text": "language: php\nfile: widget.php\nkind: method\nsymbol: render\nqualified name: Widget.render\nparent symbol: Widget\nsemantic path: widget.php::Widget.render\ncontent:\npublic function render()\n    {\n        return $this->helper($this->count);\n    }"
+      },
+      "node_id": "e2c4a7b4212dce8944f0fc48afdad6f93346d782",
+      "parent": "b52b300aeacf6ceff1dcaf8fa60eb96eb74ef17a",
+      "path": "widget.php",
+      "provenance": {
+        "extractor": "chunk_file",
+        "metadata": "retrieval"
+      },
+      "qualified_name": "Widget.render",
+      "relationships": [],
+      "semantic_path": "widget.php::Widget.render",
+      "signature": null,
+      "span": {
+        "byte_end": 130,
+        "byte_start": 50,
+        "end_line": 10,
+        "start_line": 7
+      },
+      "symbol": "render",
+      "symbol_id": "c7ca73914e488590a87508b51bd39b309ca781ba"
+    }
+  ],
+  "run": {
+    "canonical": true,
+    "created_at": null,
+    "options": {
+      "fail_fast": false,
+      "include_retrieval_metadata": true,
+      "include_timings": false,
+      "language": "php",
+      "resolution_mode": "strict"
+    },
+    "root": "tests/fixtures/boundary_ir/repos/php",
+    "timings": {
+      "graph_assembly_ms": null,
+      "metadata_normalization_ms": null,
+      "parse_ms": null,
+      "resolution_ms": null,
+      "serialization_ms": null,
+      "total_ms": null
+    },
+    "tool": "treesitter-chunker",
+    "tool_version": "<tool-version>"
+  },
+  "schema_version": "2.0",
+  "source": {
+    "kind": "repository",
+    "path": "tests/fixtures/boundary_ir/repos/php"
+  }
+}

--- a/tests/fixtures/boundary_ir/golden/ruby.json
+++ b/tests/fixtures/boundary_ir/golden/ruby.json
@@ -1,0 +1,247 @@
+{
+  "diagnostics": [],
+  "edges": [],
+  "files": [
+    {
+      "content_hash": "sha1:736e169031af07f75c486b44c8c4f0ff441abe8a",
+      "diagnostics": [],
+      "id": "0dc255d17d246a4891b0e6cafdf66be9c9f81d48",
+      "language": "ruby",
+      "parser": "tree-sitter-ruby",
+      "path": "widget.rb",
+      "status": "parsed"
+    }
+  ],
+  "metrics": {
+    "ambiguous_edges": 0,
+    "diagnostics_total": 0,
+    "edges_total": 0,
+    "failure_buckets": {},
+    "files_failed": 0,
+    "files_parsed": 1,
+    "files_processed": 1,
+    "files_skipped": 0,
+    "files_total": 1,
+    "graph_failures": 0,
+    "metadata_failures": 0,
+    "nodes_total": 5,
+    "parse_failures": 0,
+    "resolved_edges": 0,
+    "serialization_failures": 0,
+    "unresolved_edges": 0
+  },
+  "nodes": [
+    {
+      "definition_id": "35310095834fec9333d9874bbd3ac7477ee2f40e",
+      "file_id": "0dc255d17d246a4891b0e6cafdf66be9c9f81d48",
+      "id": "35310095834fec9333d9874bbd3ac7477ee2f40e",
+      "identity": {
+        "source": "definition_id",
+        "value": "35310095834fec9333d9874bbd3ac7477ee2f40e"
+      },
+      "kind": "method",
+      "language": "ruby",
+      "metadata": {
+        "dependencies": [],
+        "exports": [],
+        "imports": [],
+        "parent_symbol": "Widget",
+        "semantic_text": "language: ruby\nfile: widget.rb\nkind: method\nsymbol: render\nqualified name: Widget.render\nparent symbol: Widget\nsemantic path: widget.rb::Widget.render\ncontent:\ndef render\n    helper(@count)\n  end"
+      },
+      "node_id": "418f302615f111752a66464d1b3f8eb5475fc123",
+      "parent": "624eb47dadf0e6619172cc828db43cd340bf6d33",
+      "path": "widget.rb",
+      "provenance": {
+        "extractor": "chunk_file",
+        "metadata": "retrieval"
+      },
+      "qualified_name": "Widget.render",
+      "relationships": [],
+      "semantic_path": "widget.rb::Widget.render",
+      "signature": null,
+      "span": {
+        "byte_end": 100,
+        "byte_start": 65,
+        "end_line": 8,
+        "start_line": 6
+      },
+      "symbol": "render",
+      "symbol_id": "c3c42e442612cfd37c495784fee8ba7297f4bd2c"
+    },
+    {
+      "definition_id": "52adab2ccbee230d0ea2bd938f69a3d40166c749",
+      "file_id": "0dc255d17d246a4891b0e6cafdf66be9c9f81d48",
+      "id": "52adab2ccbee230d0ea2bd938f69a3d40166c749",
+      "identity": {
+        "source": "definition_id",
+        "value": "52adab2ccbee230d0ea2bd938f69a3d40166c749"
+      },
+      "kind": "method",
+      "language": "ruby",
+      "metadata": {
+        "dependencies": [],
+        "exports": [],
+        "imports": [],
+        "parent_symbol": "Widget",
+        "semantic_text": "language: ruby\nfile: widget.rb\nkind: method\nsymbol: helper\nqualified name: Widget.helper\nparent symbol: Widget\nsemantic path: widget.rb::Widget.helper\ncontent:\ndef helper(value)\n    value + 1\n  end"
+      },
+      "node_id": "d1a4c6a33da93dd9d0df4a8d147fd86fc783ad98",
+      "parent": "624eb47dadf0e6619172cc828db43cd340bf6d33",
+      "path": "widget.rb",
+      "provenance": {
+        "extractor": "chunk_file",
+        "metadata": "retrieval"
+      },
+      "qualified_name": "Widget.helper",
+      "relationships": [],
+      "semantic_path": "widget.rb::Widget.helper",
+      "signature": null,
+      "span": {
+        "byte_end": 141,
+        "byte_start": 104,
+        "end_line": 12,
+        "start_line": 10
+      },
+      "symbol": "helper",
+      "symbol_id": "df377cb614d3dd38d8ccf5e7632222158f491836"
+    },
+    {
+      "definition_id": "5903643579d7686c6fb23f3c2144bbaf977d1009",
+      "file_id": "0dc255d17d246a4891b0e6cafdf66be9c9f81d48",
+      "id": "5903643579d7686c6fb23f3c2144bbaf977d1009",
+      "identity": {
+        "source": "definition_id",
+        "value": "5903643579d7686c6fb23f3c2144bbaf977d1009"
+      },
+      "kind": "class",
+      "language": "ruby",
+      "metadata": {
+        "dependencies": [],
+        "exports": [],
+        "imports": [],
+        "parent_symbol": null,
+        "semantic_text": "language: ruby\nfile: widget.rb\nkind: class\nsymbol: Widget\nqualified name: Widget\nsemantic path: widget.rb::Widget\ncontent:\nclass"
+      },
+      "node_id": "a1b67bffde8b1283953cb837d01b93c6482c0127",
+      "parent": "624eb47dadf0e6619172cc828db43cd340bf6d33",
+      "path": "widget.rb",
+      "provenance": {
+        "extractor": "chunk_file",
+        "metadata": "retrieval"
+      },
+      "qualified_name": "Widget",
+      "relationships": [],
+      "semantic_path": "widget.rb::Widget",
+      "signature": null,
+      "span": {
+        "byte_end": 5,
+        "byte_start": 0,
+        "end_line": 1,
+        "start_line": 1
+      },
+      "symbol": "Widget",
+      "symbol_id": "907a8933e9a738318652743631007fa2ed33b100"
+    },
+    {
+      "definition_id": "7f580379a419db28002fc841ce5f11518bb6b2f5",
+      "file_id": "0dc255d17d246a4891b0e6cafdf66be9c9f81d48",
+      "id": "7f580379a419db28002fc841ce5f11518bb6b2f5",
+      "identity": {
+        "source": "definition_id",
+        "value": "7f580379a419db28002fc841ce5f11518bb6b2f5"
+      },
+      "kind": "class",
+      "language": "ruby",
+      "metadata": {
+        "dependencies": [],
+        "exports": [],
+        "imports": [],
+        "parent_symbol": null,
+        "semantic_text": "language: ruby\nfile: widget.rb\nkind: class\nsymbol: Widget\nqualified name: Widget\nsemantic path: widget.rb::Widget\ncontent:\nclass Widget\n  def initialize(count)\n    @count = count\n  end\n\n  def render\n    helper(@count)\n  end\n\n  def helper(value)\n    value + 1\n  end\nend"
+      },
+      "node_id": "624eb47dadf0e6619172cc828db43cd340bf6d33",
+      "parent": null,
+      "path": "widget.rb",
+      "provenance": {
+        "extractor": "chunk_file",
+        "metadata": "retrieval"
+      },
+      "qualified_name": "Widget",
+      "relationships": [],
+      "semantic_path": "widget.rb::Widget",
+      "signature": null,
+      "span": {
+        "byte_end": 145,
+        "byte_start": 0,
+        "end_line": 13,
+        "start_line": 1
+      },
+      "symbol": "Widget",
+      "symbol_id": "907a8933e9a738318652743631007fa2ed33b100"
+    },
+    {
+      "definition_id": "a93d037372fa03e1ddb81e4ac27ab2d323116948",
+      "file_id": "0dc255d17d246a4891b0e6cafdf66be9c9f81d48",
+      "id": "a93d037372fa03e1ddb81e4ac27ab2d323116948",
+      "identity": {
+        "source": "definition_id",
+        "value": "a93d037372fa03e1ddb81e4ac27ab2d323116948"
+      },
+      "kind": "method",
+      "language": "ruby",
+      "metadata": {
+        "dependencies": [],
+        "exports": [],
+        "imports": [],
+        "parent_symbol": "Widget",
+        "semantic_text": "language: ruby\nfile: widget.rb\nkind: method\nsymbol: initialize\nqualified name: Widget.initialize\nparent symbol: Widget\nsemantic path: widget.rb::Widget.initialize\ncontent:\ndef initialize(count)\n    @count = count\n  end"
+      },
+      "node_id": "66963847b8aff81b52f225b9f3e5e2f537c95e2d",
+      "parent": "624eb47dadf0e6619172cc828db43cd340bf6d33",
+      "path": "widget.rb",
+      "provenance": {
+        "extractor": "chunk_file",
+        "metadata": "retrieval"
+      },
+      "qualified_name": "Widget.initialize",
+      "relationships": [],
+      "semantic_path": "widget.rb::Widget.initialize",
+      "signature": null,
+      "span": {
+        "byte_end": 61,
+        "byte_start": 15,
+        "end_line": 4,
+        "start_line": 2
+      },
+      "symbol": "initialize",
+      "symbol_id": "9ec262098b7d49c9610df9cbf9dcf8aac563446f"
+    }
+  ],
+  "run": {
+    "canonical": true,
+    "created_at": null,
+    "options": {
+      "fail_fast": false,
+      "include_retrieval_metadata": true,
+      "include_timings": false,
+      "language": "ruby",
+      "resolution_mode": "strict"
+    },
+    "root": "tests/fixtures/boundary_ir/repos/ruby",
+    "timings": {
+      "graph_assembly_ms": null,
+      "metadata_normalization_ms": null,
+      "parse_ms": null,
+      "resolution_ms": null,
+      "serialization_ms": null,
+      "total_ms": null
+    },
+    "tool": "treesitter-chunker",
+    "tool_version": "<tool-version>"
+  },
+  "schema_version": "2.0",
+  "source": {
+    "kind": "repository",
+    "path": "tests/fixtures/boundary_ir/repos/ruby"
+  }
+}

--- a/tests/fixtures/boundary_ir/golden/swift.json
+++ b/tests/fixtures/boundary_ir/golden/swift.json
@@ -1,0 +1,247 @@
+{
+  "diagnostics": [],
+  "edges": [],
+  "files": [
+    {
+      "content_hash": "sha1:914374affb6331f45928cfab145c6b25827c235b",
+      "diagnostics": [],
+      "id": "85ce94054e96365832ea9a283b0b6ccfc1aec5c4",
+      "language": "swift",
+      "parser": "tree-sitter-swift",
+      "path": "Widget.swift",
+      "status": "parsed"
+    }
+  ],
+  "metrics": {
+    "ambiguous_edges": 0,
+    "diagnostics_total": 0,
+    "edges_total": 0,
+    "failure_buckets": {},
+    "files_failed": 0,
+    "files_parsed": 1,
+    "files_processed": 1,
+    "files_skipped": 0,
+    "files_total": 1,
+    "graph_failures": 0,
+    "metadata_failures": 0,
+    "nodes_total": 5,
+    "parse_failures": 0,
+    "resolved_edges": 0,
+    "serialization_failures": 0,
+    "unresolved_edges": 0
+  },
+  "nodes": [
+    {
+      "definition_id": "5a298fb13ca7f368d503fd6adb7ac0d8c7b1ac50",
+      "file_id": "85ce94054e96365832ea9a283b0b6ccfc1aec5c4",
+      "id": "5a298fb13ca7f368d503fd6adb7ac0d8c7b1ac50",
+      "identity": {
+        "source": "definition_id",
+        "value": "5a298fb13ca7f368d503fd6adb7ac0d8c7b1ac50"
+      },
+      "kind": "class",
+      "language": "swift",
+      "metadata": {
+        "dependencies": [],
+        "exports": [],
+        "imports": [],
+        "parent_symbol": null,
+        "semantic_text": "language: swift\nfile: Widget.swift\nkind: class\nsymbol: Widget\nqualified name: Widget\nsemantic path: Widget.swift::Widget\ncontent:\nclass Widget {\n    var count: Int = 0\n\n    func render() -> Int {\n        return helper(count)\n    }\n\n    func helper(_ value: Int) -> Int {\n        return value + 1\n    }\n}"
+      },
+      "node_id": "b1e80617ae1a4d3e5ab0176b97524c3b9504e728",
+      "parent": null,
+      "path": "Widget.swift",
+      "provenance": {
+        "extractor": "chunk_file",
+        "metadata": "retrieval"
+      },
+      "qualified_name": "Widget",
+      "relationships": [],
+      "semantic_path": "Widget.swift::Widget",
+      "signature": null,
+      "span": {
+        "byte_end": 173,
+        "byte_start": 0,
+        "end_line": 11,
+        "start_line": 1
+      },
+      "symbol": "Widget",
+      "symbol_id": "03f0ef443bd4b8fa09776e5ea6aa4ac23e6f3598"
+    },
+    {
+      "definition_id": "6b8e69e71274adbaf1ff0c800390b18c4faf998a",
+      "file_id": "85ce94054e96365832ea9a283b0b6ccfc1aec5c4",
+      "id": "6b8e69e71274adbaf1ff0c800390b18c4faf998a",
+      "identity": {
+        "source": "definition_id",
+        "value": "6b8e69e71274adbaf1ff0c800390b18c4faf998a"
+      },
+      "kind": "function",
+      "language": "swift",
+      "metadata": {
+        "dependencies": [],
+        "exports": [],
+        "imports": [],
+        "parent_symbol": null,
+        "semantic_text": "language: swift\nfile: Widget.swift\nkind: function\nsymbol: run\nqualified name: run\nsemantic path: Widget.swift::run\ncontent:\nfunc run() -> Int {\n    return Widget().render()\n}"
+      },
+      "node_id": "40ac2f910e6e3bb1854ee0aacc4370e122f4bd11",
+      "parent": null,
+      "path": "Widget.swift",
+      "provenance": {
+        "extractor": "chunk_file",
+        "metadata": "retrieval"
+      },
+      "qualified_name": "run",
+      "relationships": [],
+      "semantic_path": "Widget.swift::run",
+      "signature": null,
+      "span": {
+        "byte_end": 225,
+        "byte_start": 175,
+        "end_line": 15,
+        "start_line": 13
+      },
+      "symbol": "run",
+      "symbol_id": "d6a1a7b04a991b73823ee89c9bf55256c07b4bf3"
+    },
+    {
+      "definition_id": "89c9baae6cf09e364f31cef19341944bbc473bee",
+      "file_id": "85ce94054e96365832ea9a283b0b6ccfc1aec5c4",
+      "id": "89c9baae6cf09e364f31cef19341944bbc473bee",
+      "identity": {
+        "source": "definition_id",
+        "value": "89c9baae6cf09e364f31cef19341944bbc473bee"
+      },
+      "kind": "method",
+      "language": "swift",
+      "metadata": {
+        "dependencies": [],
+        "exports": [],
+        "imports": [],
+        "parent_symbol": "Widget",
+        "semantic_text": "language: swift\nfile: Widget.swift\nkind: method\nsymbol: helper\nqualified name: Widget.helper\nparent symbol: Widget\nsemantic path: Widget.swift::Widget.helper\ncontent:\nfunc helper(_ value: Int) -> Int {\n        return value + 1\n    }"
+      },
+      "node_id": "4169568e3b87dbe6eec14ccc64851482b8055f87",
+      "parent": "b1e80617ae1a4d3e5ab0176b97524c3b9504e728",
+      "path": "Widget.swift",
+      "provenance": {
+        "extractor": "chunk_file",
+        "metadata": "retrieval"
+      },
+      "qualified_name": "Widget.helper",
+      "relationships": [],
+      "semantic_path": "Widget.swift::Widget.helper",
+      "signature": null,
+      "span": {
+        "byte_end": 171,
+        "byte_start": 106,
+        "end_line": 10,
+        "start_line": 8
+      },
+      "symbol": "helper",
+      "symbol_id": "4ef3a2ea7d06d5326ce666bffb4386cdd7a85546"
+    },
+    {
+      "definition_id": "b8469fa43030f1a63e96494c6bb1fcb8cbff3172",
+      "file_id": "85ce94054e96365832ea9a283b0b6ccfc1aec5c4",
+      "id": "b8469fa43030f1a63e96494c6bb1fcb8cbff3172",
+      "identity": {
+        "source": "definition_id",
+        "value": "b8469fa43030f1a63e96494c6bb1fcb8cbff3172"
+      },
+      "kind": "property_declaration",
+      "language": "swift",
+      "metadata": {
+        "dependencies": [],
+        "exports": [],
+        "imports": [],
+        "parent_symbol": "Widget",
+        "semantic_text": "language: swift\nfile: Widget.swift\nkind: property_declaration\nsymbol: count\nqualified name: Widget.count\nparent symbol: Widget\nsemantic path: Widget.swift::Widget.count\ncontent:\nvar count: Int = 0"
+      },
+      "node_id": "12c60e889bc83d289e0faf8f8093ab2919f60546",
+      "parent": "b1e80617ae1a4d3e5ab0176b97524c3b9504e728",
+      "path": "Widget.swift",
+      "provenance": {
+        "extractor": "chunk_file",
+        "metadata": "retrieval"
+      },
+      "qualified_name": "Widget.count",
+      "relationships": [],
+      "semantic_path": "Widget.swift::Widget.count",
+      "signature": null,
+      "span": {
+        "byte_end": 37,
+        "byte_start": 19,
+        "end_line": 2,
+        "start_line": 2
+      },
+      "symbol": "count",
+      "symbol_id": "7138e864d0d32b6604a5e7f93ec4103b9050e842"
+    },
+    {
+      "definition_id": "f8877a6af7ebbb7bcf2483a4a4bb5979c9027e0f",
+      "file_id": "85ce94054e96365832ea9a283b0b6ccfc1aec5c4",
+      "id": "f8877a6af7ebbb7bcf2483a4a4bb5979c9027e0f",
+      "identity": {
+        "source": "definition_id",
+        "value": "f8877a6af7ebbb7bcf2483a4a4bb5979c9027e0f"
+      },
+      "kind": "method",
+      "language": "swift",
+      "metadata": {
+        "dependencies": [],
+        "exports": [],
+        "imports": [],
+        "parent_symbol": "Widget",
+        "semantic_text": "language: swift\nfile: Widget.swift\nkind: method\nsymbol: render\nqualified name: Widget.render\nparent symbol: Widget\nsemantic path: Widget.swift::Widget.render\ncontent:\nfunc render() -> Int {\n        return helper(count)\n    }"
+      },
+      "node_id": "30e21bf6c32b82d3bd359a674cfefdc71aa8df4e",
+      "parent": "b1e80617ae1a4d3e5ab0176b97524c3b9504e728",
+      "path": "Widget.swift",
+      "provenance": {
+        "extractor": "chunk_file",
+        "metadata": "retrieval"
+      },
+      "qualified_name": "Widget.render",
+      "relationships": [],
+      "semantic_path": "Widget.swift::Widget.render",
+      "signature": null,
+      "span": {
+        "byte_end": 100,
+        "byte_start": 43,
+        "end_line": 6,
+        "start_line": 4
+      },
+      "symbol": "render",
+      "symbol_id": "2f9f6c9b089629632620459cecd35732f90360b9"
+    }
+  ],
+  "run": {
+    "canonical": true,
+    "created_at": null,
+    "options": {
+      "fail_fast": false,
+      "include_retrieval_metadata": true,
+      "include_timings": false,
+      "language": "swift",
+      "resolution_mode": "strict"
+    },
+    "root": "tests/fixtures/boundary_ir/repos/swift",
+    "timings": {
+      "graph_assembly_ms": null,
+      "metadata_normalization_ms": null,
+      "parse_ms": null,
+      "resolution_ms": null,
+      "serialization_ms": null,
+      "total_ms": null
+    },
+    "tool": "treesitter-chunker",
+    "tool_version": "<tool-version>"
+  },
+  "schema_version": "2.0",
+  "source": {
+    "kind": "repository",
+    "path": "tests/fixtures/boundary_ir/repos/swift"
+  }
+}

--- a/tests/fixtures/boundary_ir/repos/c/widget.c
+++ b/tests/fixtures/boundary_ir/repos/c/widget.c
@@ -1,0 +1,11 @@
+struct Widget {
+    int count;
+};
+
+int helper(int value) {
+    return value + 1;
+}
+
+int render(struct Widget *w) {
+    return helper(w->count);
+}

--- a/tests/fixtures/boundary_ir/repos/cpp/widget.cpp
+++ b/tests/fixtures/boundary_ir/repos/cpp/widget.cpp
@@ -1,0 +1,19 @@
+enum Color { RED, GREEN, BLUE };
+
+class Widget {
+public:
+    int count;
+
+    int render() {
+        return helper();
+    }
+
+    int helper() {
+        return count + 1;
+    }
+};
+
+int run() {
+    Widget w;
+    return w.render();
+}

--- a/tests/fixtures/boundary_ir/repos/java/Widget.java
+++ b/tests/fixtures/boundary_ir/repos/java/Widget.java
@@ -1,0 +1,23 @@
+package app;
+
+public class Widget {
+    private int count;
+
+    public Widget(int count) {
+        this.count = count;
+    }
+
+    public int render() {
+        return helper(count);
+    }
+
+    private int helper(int value) {
+        return value + 1;
+    }
+}
+
+enum Color {
+    RED,
+    GREEN,
+    BLUE
+}

--- a/tests/fixtures/boundary_ir/repos/kotlin/Widget.kt
+++ b/tests/fixtures/boundary_ir/repos/kotlin/Widget.kt
@@ -1,0 +1,15 @@
+package app
+
+class Widget(val count: Int) {
+    fun render(): Int {
+        return helper(count)
+    }
+
+    fun helper(value: Int): Int {
+        return value + 1
+    }
+}
+
+fun run(): Int {
+    return Widget(1).render()
+}

--- a/tests/fixtures/boundary_ir/repos/php/widget.php
+++ b/tests/fixtures/boundary_ir/repos/php/widget.php
@@ -1,0 +1,22 @@
+<?php
+
+class Widget
+{
+    public $count = 0;
+
+    public function render()
+    {
+        return $this->helper($this->count);
+    }
+
+    public function helper($value)
+    {
+        return $value + 1;
+    }
+}
+
+function run()
+{
+    $w = new Widget();
+    return $w->render();
+}

--- a/tests/fixtures/boundary_ir/repos/ruby/widget.rb
+++ b/tests/fixtures/boundary_ir/repos/ruby/widget.rb
@@ -1,0 +1,13 @@
+class Widget
+  def initialize(count)
+    @count = count
+  end
+
+  def render
+    helper(@count)
+  end
+
+  def helper(value)
+    value + 1
+  end
+end

--- a/tests/fixtures/boundary_ir/repos/swift/Widget.swift
+++ b/tests/fixtures/boundary_ir/repos/swift/Widget.swift
@@ -1,0 +1,15 @@
+class Widget {
+    var count: Int = 0
+
+    func render() -> Int {
+        return helper(count)
+    }
+
+    func helper(_ value: Int) -> Int {
+        return value + 1
+    }
+}
+
+func run() -> Int {
+    return Widget().render()
+}

--- a/tests/test_boundary_ir_determinism.py
+++ b/tests/test_boundary_ir_determinism.py
@@ -3,6 +3,9 @@ import pytest
 from chunker.boundary import dumps_boundary_ir, extract_boundary_ir
 from tests.boundary_ir_conformance import (
     P0_BOUNDARY_LANGUAGES,
+    SUPPORTED_BOUNDARY_LANGUAGES,
+    assert_extraction_nonempty,
+    assert_grammar_runtime_pins,
     fixture_boundary_json_bytes,
 )
 
@@ -13,6 +16,26 @@ def test_fixture_boundary_ir_is_byte_identical_across_double_run(language: str):
     second = fixture_boundary_json_bytes(language)
 
     assert first == second
+
+
+@pytest.mark.parametrize("language", SUPPORTED_BOUNDARY_LANGUAGES)
+def test_extraction_nonempty(language: str):
+    """Every supported language must extract at least one boundary node.
+
+    Loud guard for the silent-``{}`` failure mode (a grammar that is "available"
+    but emits nothing, e.g. an ABI mismatch). Without this, an empty IR could
+    pass golden equality against an equally-empty golden.
+    """
+    assert_extraction_nonempty(language)
+
+
+def test_grammar_runtime_pins_match():
+    """The installed grammar/runtime versions must stay inside the pyproject pins.
+
+    Fails closed on an unintended transitive bump (e.g. tree_sitter 0.24 -> 0.25)
+    that would silently corrupt the Boundary IR.
+    """
+    assert_grammar_runtime_pins()
 
 
 def test_diagnostic_boundary_ir_is_byte_identical_across_double_run(

--- a/tests/test_boundary_ir_golden_snapshots.py
+++ b/tests/test_boundary_ir_golden_snapshots.py
@@ -5,13 +5,13 @@ import pytest
 from chunker.boundary import dumps_boundary_ir
 from tests.boundary_ir_conformance import (
     GOLDEN_ROOT,
-    P0_BOUNDARY_LANGUAGES,
+    SUPPORTED_BOUNDARY_LANGUAGES,
     extract_fixture_ir,
     normalize_ir_for_golden,
 )
 
 
-@pytest.mark.parametrize("language", P0_BOUNDARY_LANGUAGES)
+@pytest.mark.parametrize("language", SUPPORTED_BOUNDARY_LANGUAGES)
 def test_boundary_ir_golden_snapshot(language: str):
     actual_ir = normalize_ir_for_golden(extract_fixture_ir(language))
     golden_path = GOLDEN_ROOT / f"{language}.json"


### PR DESCRIPTION
## Summary

Extends the existing boundary-IR golden conformance suite from the 4 P0 languages (python/js/ts/go) to **all 11 supported languages**, and adds two new fail-loud guards so silent grammar/runtime drift in the canonical Boundary IR fails in CI. This is an **extension** of the existing suite, not a new system — **additive / guard-only, no extraction behavior changed**.

### Motivating failures this cycle (neither failed loudly before)
- **C#** silently emitted `{}` when the language pack shipped an ABI-15 grammar incompatible with the pinned `tree_sitter 0.24`.
- A `tree_sitter 0.24→0.25` bump silently **dropped Python docstrings** from the IR.

## What changed

**Per-language golden coverage**
- New `SUPPORTED_BOUNDARY_LANGUAGES` = python, javascript, typescript, go, java, cpp, c, ruby, kotlin, swift, php (11). `P0_BOUNDARY_LANGUAGES` left untouched (it's the separate semantic-parity contract).
- **C# deliberately excluded** with an inline comment — its `tree-sitter-c-sharp` grammar is ABI-15, incompatible with the pinned `tree_sitter 0.24`, so it silently emits zero boundaries. Out until the grammar ABI is fixed (PR #77).
- `test_boundary_ir_golden_snapshot` now parametrized over `SUPPORTED_BOUNDARY_LANGUAGES`. 7 new committed goldens generated **on the pinned stack** (tree_sitter 0.24.0 / language-pack 0.9.0) via the regenerate script. The existing 4 goldens are **byte-identical** (verified zero diff — proving no behavior change).
- 7 new fixture repos exercising class/method/field/enum/function per language.

**Non-empty guard** — `test_extraction_nonempty[<lang>]`: fails loudly if any supported language emits zero boundary nodes (the silent-`{}` / ABI-mismatch case that golden equality alone misses if the golden were also empty).

**Fail-closed pin guard** — `test_grammar_runtime_pins_match`: asserts installed `tree_sitter` / `tree-sitter-language-pack` versions stay inside the pyproject pins.

**Regenerate script** — `scripts/regenerate_boundary_goldens.py`: the sole sanctioned, idempotent golden path (`json.dumps(indent=2, sort_keys=True)` + trailing newline; root-independent — goldens embed no absolute paths; fails closed on off-pin stack before writing). Running it twice yields no git diff.

**Wiring / docs** — added `test_boundary_ir_determinism.py` to `scripts/run_ci_smoke.py`; `.gitignore` negation so the `ruby/` fixture isn't swallowed by the "downloaded test repos" ignore patterns; CHANGELOG + AGENTS.md ("Changing the Boundary IR") notes.

## Evidence the gate BITES (not just passes)

**(a) Golden drift caught** — hand-edited `java.json` node[0].qualified_name → `CORRUPTED_BY_DEMO`:
```
FAILED test_boundary_ir_golden_snapshot[java]
AssertionError: Boundary IR golden snapshot changed for java; review the
canonical output and update the snapshot intentionally.
```
Reverted; java snapshot green again.

**(b) Silent-`{}` caught** — temporarily added `c_sharp` to `SUPPORTED_BOUNDARY_LANGUAGES` with the ABI-15 grammar installed:
```
csharp extracted nodes = 0
FAILED test_extraction_nonempty[c_sharp]
AssertionError: c_sharp extracted zero boundary nodes from its fixture repo;
the grammar is missing, ABI-mismatched, or emitting an empty IR. This is the
silent-empty failure mode the determinism gate exists to catch ...
```
Reverted. (The CI smoke run also surfaces the underlying warning: `csharp ... Incompatible Language version 15. Must be between 13 and 14`.)

**(c) Pin drift caught (fail-closed)** — scratch venv, `tree_sitter==0.25.2`:
```
FAILED test_grammar_runtime_pins_match
AssertionError: tree_sitter==0.25.2 is outside the pinned range >=0.24,<0.25.
An unintended transitive bump tripped the determinism gate. ...
```

**(d) Regenerate idempotent** — ran `scripts/regenerate_boundary_goldens.py` twice on the committed tree → **zero git diff across both re-runs**.

## Verification (pinned stack: tree_sitter 0.24.0 / language-pack 0.9.0, Python 3.11)
- `tests/test_boundary_ir_golden_snapshots.py` + `tests/test_boundary_ir_determinism.py`: 28 passed.
- Full boundary suite (`pytest tests/ -k boundary`): **178 passed**, existing tests unchanged + green.
- `scripts/run_ci_smoke.py`: 185 passed.
- `black --check` + `ruff check` clean on all changed files.

## Deviation from the plan (flagged deliberately)
The plan's change list said to add 7 entries to `tests/fixtures/boundary_ir/manifest.json`. **I did not** — `tests/test_boundary_ir_fixture_inventory.py:26` hard-asserts `tuple(manifest) == ("go","javascript","python","typescript")`, so adding entries would break an existing test (violates the additive constraint). Nothing in the determinism gate reads the manifest — it keys off goldens + extraction. The manifest's `expected_*` shape is the **separate P0 semantic-parity contract**, left untouched.

## Known scope (not gated)
- `PINNED_TREE_SITTER` / `PINNED_LANGUAGE_PACK` are constants in `boundary_ir_conformance.py` with a "MUST mirror pyproject.toml" comment, not auto-read from pyproject — by design, so an intentional bump forces a deliberate gate update. Demo (c) proves they fail closed.
- No `.gitattributes` in the repo; the 7 new fixtures are at exact eol parity with the existing 4 (the Linux smoke/CI lane is unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017NXPoyNcnXay4n3ay7spkz
