### PR TITLE
fix(ci): revert smoke-tier gate out of the CI batch (60-min timeout) — green main

### DIFF
--- a/scripts/run_ci_smoke.py
+++ b/scripts/run_ci_smoke.py
@@ -27,11 +27,14 @@ CI_SMOKE_TESTS = [
     # Determinism gate: per-language golden non-empty guard + fail-closed
     # grammar/runtime pin assertion (the silent-{} and ABI-drift failure modes).
     "tests/test_boundary_ir_determinism.py",
-    # Smoke-tier coverage gate: comprehensive LOAD smoke across the ENTIRE pack
-    # (every grammar must load under the pin -- forward ABI-drift tripwire) plus
-    # per-language coverage diffed against the committed docs/language-coverage
-    # .json oracle. Complements the deep 12-language golden gate above.
-    "tests/test_language_smoke.py",
+    # Smoke-tier coverage gate (tests/test_language_smoke.py): TEMPORARILY removed
+    # from the standing CI batch -- it blew the 60-min Pytest step on a fresh CI
+    # runner (the built-grammar-lib extraction path, not the test logic, which is
+    # ~0.3s via the pack). The test file + docs/language-coverage.{md,json} oracle
+    # remain committed and runnable locally; it will be re-added once the CI perf
+    # fix lands (branch fix/smoke-gate-ci-timeout). Reverted-to-green per the
+    # revert-then-fix-forward discipline; the gate's VALUE is preserved, only its
+    # CI wiring is paused.
 ]
 
 


### PR DESCRIPTION
PR #83's language-smoke gate blew the 60-min ci.yml Pytest step on a fresh CI runner (the built-grammar-lib path, not the test logic which is ~0.3s via the pack). This removes it from the standing CI batch to restore a green main; the test + coverage oracle stay committed. Re-added once the perf fix (fix/smoke-gate-ci-timeout) lands. Revert-then-fix-forward.