### PR TITLE
fix(ci): smoke gate Pytest 60-min hang — pin pack to locked 0.9.0 (CI floated to 0.13.0, whose cobol grammar infinite-loops in parser.parse, unkillable by signal timeout)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,33 @@ jobs:
         run: |
           # toml, httpx, and jsonschema are declared in the [dev] extra, so the
           # single editable install below covers them -- no ad-hoc pip installs.
-          uv pip install --system -e ".[dev,api,viz,templates,advanced]"
+          #
+          # Pin tree-sitter-language-pack to the LOCKED 0.9.0 explicitly. `uv pip
+          # install` does NOT consult uv.lock, so the pyproject `>=0.9,<1.0` range
+          # otherwise floats to the newest pack on every CI run. That float is not
+          # cosmetic: the language-coverage smoke gate is baked against 0.9.0 (the
+          # byte-stable, ABI-paired pin its oracle + pin asserts demand), and a
+          # newer pack ships a `cobol` grammar that infinite-loops in
+          # `parser.parse()` at the C level -- which pytest-timeout's signal-based
+          # interrupt CANNOT kill, so the LOAD smoke hung the whole Pytest step to
+          # the 60-min wall. Pinning here keeps CI on the env the gate is designed
+          # for. When the pack pin is next bumped, regenerate the coverage oracle
+          # AND add a hard-kill (subprocess) hang-guard to the load smoke first --
+          # the cobol C-hang is latent until then.
+          uv pip install --system -e ".[dev,api,viz,templates,advanced]" \
+            "tree-sitter-language-pack==0.9.0"
+          # Fail loudly (not silently green) if the install resolved a different
+          # pack than the gate's oracle was baked against.
+          python - <<'PY'
+          import importlib.metadata as m
+          expected = "0.9.0"
+          installed = m.version("tree-sitter-language-pack")
+          assert installed == expected, (
+              f"tree-sitter-language-pack=={installed} but the smoke-gate oracle "
+              f"is baked against {expected}; the CI install must stay on the pin."
+          )
+          print(f"tree-sitter-language-pack pinned at {installed}")
+          PY
 
       - name: Fetch grammars
         run: python scripts/fetch_grammars.py


### PR DESCRIPTION
## The bug

The language-coverage smoke gate (#83) blew the `ci.yml` `test` job's **Pytest** step to the **60-minute** wall. It is **not** a slowness problem — the gate runs in **<4s** under its intended pin.

## Profiled bottleneck (root cause)

`uv pip install` does **not** consult `uv.lock`. So the pyproject range `tree-sitter-language-pack>=0.9,<1.0` floats to the **newest** pack (`0.13.0`) on every CI run, instead of the **locked `0.9.0`** that the gate's coverage oracle and pin asserts are baked against.

`0.13.0` enumerates 173 languages (vs the oracle's 167) and ships a new **`cobol`** grammar that **infinite-loops inside `parser.parse()` at the C level**. Isolated proof: `get_language('cobol')` loads fine, but `parser.parse(b"a")` never returns (process killed at the external cap, exit 124).

`pytest-timeout` is **signal-based** and cannot interrupt a C loop that executes no Python bytecode. So `test_every_pack_language_loads[cobol]` hangs its `pytest-xdist` worker forever, and the whole Pytest step runs to the 60-min timeout.

The failed CI run's log matches this exactly:
- fast to `[78%]`,
- a single `F` at ~59% (that is `test_pack_pinned_exactly_at_committed_version` **correctly** failing on `0.13.0 != 0.9.0`),
- then dead until `##[error]The action 'Pytest' has timed out after 60 minutes.` — **never reaching 100%**.

Under `0.9.0`, `cobol` is not even a pack grammar, so the LOAD smoke never parses it. That is why the gate is fast locally.

## The fix

One change in `ci.yml`: pin the install to the locked `0.9.0` explicitly and assert the installed version post-install, keeping CI on the byte-stable, ABI-paired environment the gate is designed for.

- **No test-logic change.** The gate's value is fully intact: all pack languages load + the per-language coverage diff against the committed `docs/language-coverage.json` oracle + the sampled-nonempty guard.
- No perf refactor, no extraction-path change, no behavior change.

## Before / after (CI-exact env: Python 3.11, full extras `[dev,api,viz,templates,advanced]`, `build/` populated via fetch+build grammars)

| | pack | `python scripts/run_ci_smoke.py` |
|---|---|---|
| **Before** | `0.13.0` (floated) | **60-min hang** — full batch reaches `[98%]` then hangs on `cobol`, never completes |
| **After** | `0.9.0` (pinned) | **360 passed in 3.68s** (4.12s wall), all gates green |

The deep golden/determinism gates (`test_boundary_ir_golden_snapshots`, `test_boundary_ir_determinism`, `test_boundary_determinism`, `test_boundary_parity_view`, `test_boundary_ir_schema`) are part of that 360 and stay green.

## Latent follow-up (flagged, not fixed here)

Pinning fixes today, but the `cobol` C-hang **detonates the moment anyone bumps the pack pin**. When the pack is next bumped: regenerate the coverage oracle **and** add a hard-kill (subprocess) hang-guard to the load smoke **before** flipping the pin, so a single pathological grammar can never burn the CI budget again.

Separately: `pyproject` declares `>=0.9,<1.0` while its own comment says "held at 0.9.x". That loose `<1.0` is what lets CI (and `test.yml`, and contributor machines) float off-pin. Tightening to `<0.10` would match the documented intent and stop recurrence on all install paths — left out of this PR as it changes declared deps; happy to add if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017NXPoyNcnXay4n3ay7spkz