### PR TITLE
fix(ci): re-land smoke gate working — pin pack to 0.9.0 + cap <0.10 (3.2.1); root cause was a floated 0.13.0 cobol grammar that C-hangs parser.parse

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,34 @@ jobs:
         run: |
           # toml, httpx, and jsonschema are declared in the [dev] extra, so the
           # single editable install below covers them -- no ad-hoc pip installs.
-          uv pip install --system -e ".[dev,api,viz,templates,advanced]"
+          #
+          # Pin tree-sitter-language-pack to the LOCKED 0.9.0 explicitly. `uv pip
+          # install` does NOT consult uv.lock, so the pyproject range otherwise
+          # floats to the newest pack on every CI run. That float is not cosmetic:
+          # the language-coverage smoke gate is baked against 0.9.0 (the
+          # byte-stable, ABI-paired pin its oracle + pin asserts demand), and a
+          # newer pack ships a `cobol` grammar that infinite-loops in
+          # `parser.parse()` at the C level -- which pytest-timeout's signal-based
+          # interrupt CANNOT kill, so the LOAD smoke hung the whole Pytest step to
+          # the 60-min wall (the bug behind the #84 revert). pyproject now caps the
+          # pack at <0.10, so this `==0.9.0` is belt-and-suspenders pinning the
+          # exact patch CI runs on. When the pack pin is next bumped, regenerate
+          # the coverage oracle AND add a hard-kill (subprocess) hang-guard to the
+          # load smoke first -- the cobol C-hang is latent until then.
+          uv pip install --system -e ".[dev,api,viz,templates,advanced]" \
+            "tree-sitter-language-pack==0.9.0"
+          # Fail loudly (not silently green) if the install resolved a different
+          # pack than the gate's oracle was baked against.
+          python - <<'PY'
+          import importlib.metadata as m
+          expected = "0.9.0"
+          installed = m.version("tree-sitter-language-pack")
+          assert installed == expected, (
+              f"tree-sitter-language-pack=={installed} but the smoke-gate oracle "
+              f"is baked against {expected}; the CI install must stay on the pin."
+          )
+          print(f"tree-sitter-language-pack pinned at {installed}")
+          PY
 
       - name: Fetch grammars
         run: python scripts/fetch_grammars.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.1] - 2026-06-25
+
+### 🐛 Bug Fixes
+
+- **deps**: Cap `tree-sitter-language-pack` at `>=0.9,<0.10` (was `<1.0`). The
+  loose upper bound let the pack float off the verified, byte-stable 0.9.0
+  pairing on a plain `pip install` / `uv pip install` (which ignores `uv.lock`).
+  This is not cosmetic: pack 0.13.0 ships a `cobol` grammar that infinite-loops
+  in `parser.parse()` at the C level, which a signal-based timeout cannot
+  interrupt — it hung the language-coverage smoke step in CI for the full 60-min
+  budget. The `<0.10` cap protects pip consumers, contributor machines, and the
+  CI matrix from the same float; the byte-stable boundary-IR guarantee is only
+  verified at 0.9.x, and the determinism gate catches any 0.9.x patch drift.
+
+### 🧪 Testing / CI
+
+- **ci**: Re-land the language-coverage smoke gate (reverted in #84) into the
+  standing CI batch, now that the install pins the pack to `==0.9.0`. The gate
+  verifies all pack languages load + the per-language coverage oracle diff +
+  the sampled-nonempty guard. The CI install pins `tree-sitter-language-pack==0.9.0`
+  explicitly and asserts the resolved version post-install, so a future float
+  fails loudly instead of hanging.
+
 ## [3.2.0] - 2026-06-24
 
 ### ✨ Features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name            = "treesitter-chunker"
-version = "3.2.0"
+version = "3.2.1"
 description     = "Semantic code chunker using Tree-sitter for intelligent code analysis"
 readme          = "README.md"
 requires-python = ">=3.11"
@@ -34,11 +34,17 @@ dependencies = [
     # 0.25.x core + 0.9.x pack is the verified pairing -- the 0.25 runtime loads
     # ABI 13-15, so it accepts every grammar the 0.9.0 pack ships INCLUDING the
     # ABI-15 C# grammar that the old 0.24 runtime rejected (C# is now turnkey).
-    # Holding the pack at 0.9.x keeps boundary IR byte-stable: pack >=1.x floats a
-    # newer Python grammar that drops docstrings from semantic_text, so the pack
-    # upper bound is load-bearing, not cosmetic.
+    # Holding the pack at 0.9.x keeps boundary IR byte-stable: a newer Python
+    # grammar drops docstrings from semantic_text, so the pack upper bound is
+    # load-bearing, not cosmetic. The bound is <0.10 (NOT <1.0): the float is
+    # dangerous WITHIN the 0.x series, not just at 1.x -- pack 0.13.0 ships a
+    # `cobol` grammar that infinite-loops in parser.parse() at the C level, which
+    # a signal-based timeout cannot kill (it hung CI's smoke step for 60 min; the
+    # determinism gate catches any 0.9.x patch drift). When bumping this pin:
+    # regenerate docs/language-coverage.{md,json} on the new pack AND add a
+    # hard-kill (subprocess) hang-guard to the load smoke first.
     "tree_sitter>=0.25,<0.26",
-    "tree-sitter-language-pack>=0.9,<1.0",  # Pre-compiled grammars; ABI-paired with tree_sitter above (held at 0.9.x)
+    "tree-sitter-language-pack>=0.9,<0.10",  # Pre-compiled grammars; ABI-paired with tree_sitter above (held at 0.9.x; <0.10 is load-bearing -- see above)
     "rich>=13.0.0",
     "typer>=0.9.0",
     "pyarrow>=15.0.0",

--- a/scripts/run_ci_smoke.py
+++ b/scripts/run_ci_smoke.py
@@ -27,14 +27,20 @@ CI_SMOKE_TESTS = [
     # Determinism gate: per-language golden non-empty guard + fail-closed
     # grammar/runtime pin assertion (the silent-{} and ABI-drift failure modes).
     "tests/test_boundary_ir_determinism.py",
-    # Smoke-tier coverage gate (tests/test_language_smoke.py): TEMPORARILY removed
-    # from the standing CI batch -- it blew the 60-min Pytest step on a fresh CI
-    # runner (the built-grammar-lib extraction path, not the test logic, which is
-    # ~0.3s via the pack). The test file + docs/language-coverage.{md,json} oracle
-    # remain committed and runnable locally; it will be re-added once the CI perf
-    # fix lands (branch fix/smoke-gate-ci-timeout). Reverted-to-green per the
-    # revert-then-fix-forward discipline; the gate's VALUE is preserved, only its
-    # CI wiring is paused.
+    # Smoke-tier coverage gate: comprehensive LOAD smoke across the ENTIRE pack
+    # (every grammar must load under the pin -- forward ABI-drift tripwire) plus
+    # per-language coverage diffed against the committed docs/language-coverage
+    # .json oracle. Complements the deep 12-language golden gate above.
+    #
+    # Re-landed (previously reverted in #84) now that the CI install pins the pack
+    # to ==0.9.0. The 60-min Pytest hang was NOT the test logic or the
+    # built-grammar-lib path: `uv pip install` ignores uv.lock, so the pack
+    # floated to 0.13.0, whose `cobol` grammar infinite-loops in parser.parse() at
+    # the C level -- and pytest-timeout's signal-based interrupt cannot kill a C
+    # loop, so the load smoke hung the whole step. Under the pinned 0.9.0 (the
+    # byte-stable, ABI-paired env this gate is baked against) cobol is not even a
+    # pack grammar; the full batch runs in seconds. See .github/workflows/ci.yml.
+    "tests/test_language_smoke.py",
 ]
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -2171,7 +2171,7 @@ wheels = [
 
 [[package]]
 name = "treesitter-chunker"
-version = "3.1.0"
+version = "3.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "chardet" },
@@ -2320,7 +2320,7 @@ requires-dist = [
     { name = "tomli-w", specifier = ">=1.0.0" },
     { name = "tqdm", specifier = ">=4.66.0" },
     { name = "tree-sitter", specifier = ">=0.25,<0.26" },
-    { name = "tree-sitter-language-pack", specifier = ">=0.9,<1.0" },
+    { name = "tree-sitter-language-pack", specifier = ">=0.9,<0.10" },
     { name = "treesitter-chunker", extras = ["dev", "viz", "docs", "profile", "api", "templates", "advanced"], marker = "extra == 'all'" },
     { name = "twine", marker = "extra == 'dev'" },
     { name = "typer", specifier = ">=0.9.0" },


### PR DESCRIPTION
Re-lands the language-coverage smoke gate (reverted in #84 to keep main green) **working**, plus the dependency fix that prevents the hang for everyone — not just this CI job.

## Root cause (not slowness, not the built-lib path)

`uv pip install` does **not** consult `uv.lock`. So the pyproject range `tree-sitter-language-pack>=0.9,<1.0` floated to the **newest** pack (`0.13.0`) on every CI run, instead of the **locked `0.9.0`** the gate's coverage oracle and pin asserts are baked against.

`0.13.0` ships a new **`cobol`** grammar that **infinite-loops inside `parser.parse()` at the C level**. Isolated proof: `get_language('cobol')` loads fine, but `parser.parse(b"a")` never returns (killed at an external cap, exit 124). `pytest-timeout` is **signal-based** and cannot interrupt a C loop that runs no Python bytecode, so `test_every_pack_language_loads[cobol]` hung its `pytest-xdist` worker forever and the whole Pytest step ran to the 60-min wall.

The original failed run's log matches exactly: fast to `[78%]`, one `F` at ~59% (that is `test_pack_pinned_exactly_at_committed_version` **correctly** failing on `0.13.0 != 0.9.0`), then dead until the 60-min kill — never reaching 100%. Under `0.9.0`, `cobol` is not even a pack grammar, so the load smoke never parses it.

## Changes

- **`scripts/run_ci_smoke.py`** — re-add `tests/test_language_smoke.py` to the standing CI batch (reverts the #84 revert), now that the pin makes it fast + green.
- **`.github/workflows/ci.yml`** — pin the install to `tree-sitter-language-pack==0.9.0` and assert the resolved version post-install, so a future float fails loudly instead of hanging.
- **`pyproject.toml`** — tighten the pack cap `>=0.9,<1.0` → `>=0.9,<0.10`. The loose `<1.0` is the actual root cause and it bites **everywhere** (the published wheel, contributor machines, the `test.yml` matrix), not just this CI job. The chunker is byte-stable only at 0.9.x (verified) and the determinism gate catches any 0.9.x patch drift, so `<0.10` is correct and matches the documented "held at 0.9.x" intent.
- **Version bump `3.2.0` → `3.2.1` + CHANGELOG** — changing the published dep warrants a release; it protects pip consumers from the same float-to-`0.13.0` cobol hang. **Release-ready; NOT published** (publish is the human's gate).
- **`uv.lock`** — regenerated to sync the specifier to `<0.10`. Clean 2-line diff; it also corrects the stale project version (`3.1.0` → `3.2.1`) the lock carried. The prior 3.2.0 release deliberately did not touch the lock; CI does not use the lock for installs, so this is zero CI risk — flagging the lock churn so it is not a surprise.

No test-logic change. The gate's value is intact: all pack languages load + the per-language coverage diff against the committed `docs/language-coverage.json` oracle + the sampled-nonempty guard. The comprehensive coverage lives in two **non-parametrized, no-skip** tests — `test_coverage_matches_committed_oracle` (sweeps all 167 and diffs the full languages dict) and `test_pack_pinned_exactly_at_committed_version` (pins 0.9.0) — so reaching 100% with 0 failed proves the full sweep ran regardless of the parametrized case count.

## Before / after

| | pack | `python scripts/run_ci_smoke.py` |
|---|---|---|
| **Before** | `0.13.0` (floated) | **60-min hang** — never reaches 100% |
| **After (local CI-exact env: py3.11, full extras, `build/` populated, pack 0.9.0)** | `0.9.0` (pinned) | **360 passed in 3.29s**, all gates green |

> The authoritative after-number is whatever **this PR's `ci.yml` `test` job** prints (the parametrized load-case count collected on CI can differ from the local env). `360` above is the local CI-exact run; the gate's comprehensive 167-sweep is in the non-parametrized oracle test either way.

## Latent follow-up (flagged, not fixed here, per the agreed plan)

Pinning + the `<0.10` cap fix this today, but the `cobol` C-hang **detonates the moment anyone bumps the pack pin**. Before any future bump: regenerate `docs/language-coverage.{md,json}` on the new pack **and** add a hard-kill (subprocess) hang-guard to the load smoke first — a signal-based timeout cannot catch a C loop. Tracked as a roadmap hardening item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017NXPoyNcnXay4n3ay7spkz