### PR TITLE
fix(metadata): keep type annotation on TS/JS optional parameters

### DIFF
--- a/chunker/metadata/languages/javascript.py
+++ b/chunker/metadata/languages/javascript.py
@@ -304,6 +304,16 @@ class JavaScriptMetadataExtractor(BaseMetadataExtractor):
                 text = self._get_node_text(param_node, source)
                 if "?" in text:
                     param_info["name"] += "?"
+            type_node = self._find_child_by_type(param_node, "type_annotation")
+            if type_node:
+                param_info["type"] = (
+                    self._get_node_text(
+                        type_node,
+                        source,
+                    )
+                    .strip(":")
+                    .strip()
+                )
             for i, child in enumerate(param_node.children):
                 if child.type == "=":
                     next_child = self._safe_get_child(param_node, i + 1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name            = "treesitter-chunker"
-version = "3.2.1"
+version = "3.2.2"
 description     = "Semantic code chunker using Tree-sitter for intelligent code analysis"
 readme          = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_metadata_extraction.py
+++ b/tests/test_metadata_extraction.py
@@ -470,6 +470,28 @@ interface Calculator {
             assert signature is not None
             assert "interface_method" in signature.modifiers
 
+    @staticmethod
+    def test_extract_optional_parameter_type(extractor):
+        """Optional parameters (``x?: type``) must keep their type annotation.
+
+        Regression test: the ``optional_parameter`` branch of
+        ``_parse_parameter`` used to read the name but never the
+        ``type_annotation`` child, silently dropping the type for every
+        optional param while the adjacent ``required_parameter`` branch kept
+        it.
+        """
+        code = "\nfunction greet(name?: string, age: number): string {\n    return name;\n}\n"
+        parser = get_parser("typescript")
+        tree = parser.parse(code.encode())
+        func_node = tree.root_node.children[0]
+        signature = extractor.extract_signature(func_node, code.encode())
+        assert signature.name == "greet"
+        assert len(signature.parameters) == 2
+        assert signature.parameters[0]["name"] == "name?"
+        assert signature.parameters[0]["type"] == "string"
+        assert signature.parameters[1]["name"] == "age"
+        assert signature.parameters[1]["type"] == "number"
+
 
 class TestIntegrationWithChunker:
     """Test metadata extraction integration with chunker."""

--- a/uv.lock
+++ b/uv.lock
@@ -2171,7 +2171,7 @@ wheels = [
 
 [[package]]
 name = "treesitter-chunker"
-version = "3.2.1"
+version = "3.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "chardet" },


### PR DESCRIPTION
## Summary

- `chunker/metadata/languages/javascript.py`'s `optional_parameter` branch of `_parse_parameter` read the parameter name but never its `type_annotation` child, unlike the adjacent `required_parameter` branch which does. TS `foo(x?: string)` parses `x?` as an `optional_parameter` node whose `type_annotation` child holds `: string` — the type was silently dropped.
- Confirmed at scale on real gp source: **564/2,153 (26%) of extracted params are optional, and 0 kept their type** before this fix.
- Fix mirrors the `required_parameter` branch exactly (same `type_annotation` lookup, same `.strip(":").strip()` normalization, same output shape) so an optional param now keeps its type.
- This type flows straight through to `signature_text` (`chunker/core.py::_format_signature_text`) and from there into the Boundary IR `signature` field (`chunker/boundary/adapter.py`), so the fix reaches every consumer of the extracted metadata/Boundary IR, not just the raw parameter list.
- Version bumped `3.2.1` → `3.2.2` (patch/bugfix) since this changes parser output for any TS/JS source that uses optional typed parameters.

## Verification

- Added a regression test, `TestTypeScriptMetadataExtraction::test_extract_optional_parameter_type` in `tests/test_metadata_extraction.py`, asserting `foo(name?: string, age: number)` keeps `parameters[0]["type"] == "string"`. Confirmed red-without / green-with the fix (stashed the source change, reran — test failed with `type == None`; restored — passed).
- Ran the repo's Boundary IR golden regen (`scripts/regenerate_boundary_goldens.py`) — **all 12 language goldens report `unchanged`**. This is expected, not a gap in the fix: none of the current `tests/fixtures/boundary_ir/repos/{javascript,typescript}/*` fixtures happen to contain an optional typed parameter (`x?: T`), so the fixture corpus can't exercise this bug either way. I did not hand-edit the fixtures to add one — doing so would ripple into `test_boundary_ir_fixture_inventory.py` and related count/inventory assertions for marginal benefit versus the direct unit test above, which is a precise, minimal repro of the exact bug. Flagging the gap explicitly: **the Boundary IR determinism gate does not currently have coverage for optional typed parameters in any language**, so a future regression here would not be caught by goldens alone.
- Ran `tests/test_metadata_extraction.py`, `tests/test_javascript_language.py`, `tests/test_typescript_language.py`, `tests/test_boundary_ir_*` (golden snapshots, determinism, semantic contract, schema, language parity) — all pass.
- Ran the full fast CI-equivalent suite (`scripts/run_ci_smoke.py`) — 360 passed.
- `ruff check` and `black --check` — clean.
- `uv lock` — regenerated to match the version bump.

### Pre-existing gap noticed, left out of scope

While comparing branches: `required_parameter` with a typed default (e.g. TS `age: number = 18`) does **not** capture the default value — only `optional_parameter` and bare `assignment_pattern` do. That's a separate, narrower gap unrelated to this fix; not touched here.

## Downstream consumers that will need attention on upgrade

- **`spec`'s `spec-engine/realized/adapter.py` E(C) pipeline** — this is the consumer named in the task. It pins to `treesitter-chunker==3.2.0` by version string in code/docstrings (`EC_SOURCE`, docstrings referencing "GENUINE treesitter-chunker 3.2.0 Boundary IR"), and `spec-engine/realized/test_realized.py:70-71` hard-asserts `ec1["provenance"]["tsc_version"] == "3.2.0"` / `X.tsc_version() == "3.2.0"`. **These version-string assertions will break on any bump to `3.2.2` regardless of output content** — that's a required update independent of this fix.
- **Golden/digest regen in `spec`**: I checked (`grep -rnE '[A-Za-z_]\?:' spec-engine/realized/sample* spec-engine/**/*.json`) and **none of spec's current sample fixtures or correspondence/graph JSON contain an optional typed parameter**, so **no actual golden/digest content in spec needs regenerating from this specific fix** — only the hardcoded version-string pins above need updating. If spec's fixtures grow an optional typed param later, this fix will change output for it and any pinned digest would need regen at that point.
- Not touched: no other repo scanned (`Code-Index-MCP`, `governed-pipeline`, `portal`, etc.) had a live pin exercising this code path at the time of this check.

**Do not merge — isolated worktree, opened for review per instructions.**

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>